### PR TITLE
Add missing XML docs

### DIFF
--- a/src/vanillapdf.net/PdfContents/PdfContentInstructionCollectionIterator.cs
+++ b/src/vanillapdf.net/PdfContents/PdfContentInstructionCollectionIterator.cs
@@ -76,6 +76,7 @@ namespace vanillapdf.net.PdfContents
         private bool isFirst = true;
 
         object IEnumerator.Current => GetValue();
+        /// <inheritdoc />
         public PdfContentInstruction Current => GetValue();
 
         /// <inheritdoc />

--- a/src/vanillapdf.net/PdfContents/PdfContentOperation.cs
+++ b/src/vanillapdf.net/PdfContents/PdfContentOperation.cs
@@ -24,6 +24,9 @@ namespace vanillapdf.net.PdfContents
             RuntimeHelpers.RunClassConstructor(typeof(PdfContentOperationSafeHandle).TypeHandle);
         }
 
+        /// <summary>
+        /// Derived type of the operation represented by this instance.
+        /// </summary>
         public PdfContentOperationType OperationType
         {
             get { return GetOperationType(); }

--- a/src/vanillapdf.net/PdfSemantics/PdfPageObject.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfPageObject.cs
@@ -27,12 +27,18 @@ namespace vanillapdf.net.PdfSemantics
             RuntimeHelpers.RunClassConstructor(typeof(PdfPageObjectSafeHandle).TypeHandle);
         }
 
+        /// <summary>
+        /// The media box defining the visible region of the page.
+        /// </summary>
         public PdfRectangle MediaBox
         {
             get { return GetMediaBox(); }
             set { SetMediaBox(value); }
         }
 
+        /// <summary>
+        /// Underlying page dictionary object.
+        /// </summary>
         public PdfDictionaryObject BaseObject
         {
             get => GetBaseObject();

--- a/src/vanillapdf.net/PdfSemantics/PdfRectangle.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfRectangle.cs
@@ -6,6 +6,9 @@ using vanillapdf.net.Utils;
 
 namespace vanillapdf.net.PdfSemantics
 {
+    /// <summary>
+    /// Represents a rectangular region using integer coordinates.
+    /// </summary>
     public class PdfRectangle : PdfUnknown
     {
         internal PdfRectangleSafeHandle Handle { get; }
@@ -21,24 +24,36 @@ namespace vanillapdf.net.PdfSemantics
             RuntimeHelpers.RunClassConstructor(typeof(PdfRectangleSafeHandle).TypeHandle);
         }
 
+        /// <summary>
+        /// Lower-left X coordinate of the rectangle.
+        /// </summary>
         public Int64 LowerLeftX
         {
             get { return GetLowerLeftX(); }
             set { SetLowerLeftX(value); }
         }
 
+        /// <summary>
+        /// Lower-left Y coordinate of the rectangle.
+        /// </summary>
         public Int64 LowerLeftY
         {
             get { return GetLowerLeftY(); }
             set { SetLowerLeftY(value); }
         }
 
+        /// <summary>
+        /// Upper-right X coordinate of the rectangle.
+        /// </summary>
         public Int64 UpperRightX
         {
             get { return GetUpperRightX(); }
             set { SetUpperRightX(value); }
         }
 
+        /// <summary>
+        /// Upper-right Y coordinate of the rectangle.
+        /// </summary>
         public Int64 UpperRightY
         {
             get { return GetUpperRightY(); }

--- a/src/vanillapdf.net/PdfSyntax/PdfDictionaryObjectIterator.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfDictionaryObjectIterator.cs
@@ -8,6 +8,9 @@ using vanillapdf.net.Utils;
 
 namespace vanillapdf.net.PdfSyntax
 {
+    /// <summary>
+    /// Iterator over the key-value pairs of a PDF dictionary object.
+    /// </summary>
     public class PdfDictionaryObjectIterator : PdfUnknown, IEnumerator<KeyValuePair<PdfNameObject, PdfObject>>
     {
         internal PdfDictionaryObjectIteratorSafeHandle Handle { get; }

--- a/src/vanillapdf.net/PdfSyntax/PdfIndirectReferenceObject.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfIndirectReferenceObject.cs
@@ -24,6 +24,9 @@ namespace vanillapdf.net.PdfSyntax
             RuntimeHelpers.RunClassConstructor(typeof(PdfIndirectReferenceObjectSafeHandle).TypeHandle);
         }
 
+        /// <summary>
+        /// Object referenced by this indirect reference.
+        /// </summary>
         public PdfObject ReferencedObject
         {
             get { return GetReferencedObject(); }

--- a/src/vanillapdf.net/PdfSyntax/PdfNameObject.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfNameObject.cs
@@ -24,12 +24,18 @@ namespace vanillapdf.net.PdfSyntax
             RuntimeHelpers.RunClassConstructor(typeof(PdfNameObjectSafeHandle).TypeHandle);
         }
 
+        /// <summary>
+        /// Raw encoded value of the name.
+        /// </summary>
         public PdfBuffer Value
         {
             get { return GetValue(); }
             set { SetValue(value); }
         }
 
+        /// <summary>
+        /// Hash value calculated from the name string.
+        /// </summary>
         public UInt64 Hash
         {
             get { return GetHash(); }


### PR DESCRIPTION
## Summary
- document PdfRectangle class and properties
- document PdfPageObject properties
- add docs for PdfNameObject properties
- document PdfDictionaryObjectIterator class and PdfIndirectReferenceObject property
- document PdfContentOperation property and iterator Current property

## Testing
- `dotnet test -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68603c20b618832bbc21c109ad5966f4