### PR TITLE
Add XML comments to enumerations

### DIFF
--- a/src/vanillapdf.net/PdfContents/PdfContentOperationType.cs
+++ b/src/vanillapdf.net/PdfContents/PdfContentOperationType.cs
@@ -14,78 +14,224 @@
         /// Unresolved operation often containing unknown operator.
         /// </summary>
         Generic,
+
+        /// <summary>Set the current line width.</summary>
         LineWidth,
+
+        /// <summary>Set the line cap style.</summary>
         LineCap,
+
+        /// <summary>Set the line join style.</summary>
         LineJoin,
+
+        /// <summary>Set the miter limit.</summary>
         MiterLimit,
+
+        /// <summary>Define a dash pattern.</summary>
         DashPattern,
+
+        /// <summary>Specify color rendering intent.</summary>
         ColorRenderingIntent,
+
+        /// <summary>Set the flatness tolerance.</summary>
         Flatness,
+
+        /// <summary>Load a graphics state object.</summary>
         GraphicsState,
+
+        /// <summary>Save the graphics state.</summary>
         SaveGraphicsState,
+
+        /// <summary>Restore the graphics state.</summary>
         RestoreGraphicsState,
+
+        /// <summary>Modify the transformation matrix.</summary>
         TransformationMatrix,
+
+        /// <summary>Begin a new subpath.</summary>
         BeginSubpath,
+
+        /// <summary>Append a line segment.</summary>
         Line,
+
+        /// <summary>Append a complete Bézier curve.</summary>
         FullCurve,
+
+        /// <summary>Append the final control points of a Bézier curve.</summary>
         FinalCurve,
+
+        /// <summary>Append the initial control points of a Bézier curve.</summary>
         InitialCurve,
+
+        /// <summary>Close the current subpath.</summary>
         CloseSubpath,
+
+        /// <summary>Append a rectangle.</summary>
         Rectangle,
+
+        /// <summary>Stroke the current path.</summary>
         Stroke,
+
+        /// <summary>Close and stroke the current path.</summary>
         CloseAndStroke,
+
+        /// <summary>Fill path using the nonzero winding rule.</summary>
         FillPathNonzero,
+
+        /// <summary>Fill path for compatibility.</summary>
         FillPathCompatibility,
+
+        /// <summary>Fill path using the even-odd rule.</summary>
         FillPathEvenOdd,
+
+        /// <summary>Fill and then stroke path using the nonzero winding rule.</summary>
         FillStrokeNonzero,
+
+        /// <summary>Fill and then stroke path using the even-odd rule.</summary>
         FillStrokeEvenOdd,
+
+        /// <summary>Close, fill, and stroke path using the nonzero winding rule.</summary>
         CloseFillStrokeNonzero,
+
+        /// <summary>Close, fill, and stroke path using the even-odd rule.</summary>
         CloseFillStrokeEvenOdd,
+
+        /// <summary>End the path without filling or stroking.</summary>
         EndPath,
+
+        /// <summary>Modify clipping path using the nonzero winding rule.</summary>
         ClipPathNonzero,
+
+        /// <summary>Modify clipping path using the even-odd rule.</summary>
         ClipPathEvenOdd,
+
+        /// <summary>Begin a text object.</summary>
         BeginText,
+
+        /// <summary>End the current text object.</summary>
         EndText,
+
+        /// <summary>Set character spacing.</summary>
         CharacterSpacing,
+
+        /// <summary>Set word spacing.</summary>
         WordSpacing,
+
+        /// <summary>Set horizontal scaling.</summary>
         HorizontalScaling,
+
+        /// <summary>Set text leading.</summary>
         Leading,
+
+        /// <summary>Select the text font and size.</summary>
         TextFont,
+
+        /// <summary>Set text rendering mode.</summary>
         TextRenderingMode,
+
+        /// <summary>Set text rise.</summary>
         TextRise,
+
+        /// <summary>Move text position.</summary>
         TextTranslate,
+
+        /// <summary>Move text position and set leading.</summary>
         TextTranslateLeading,
+
+        /// <summary>Set text matrix.</summary>
         TextMatrix,
+
+        /// <summary>Move to start of next text line.</summary>
         TextNextLine,
+
+        /// <summary>Show a text string.</summary>
         TextShow,
+
+        /// <summary>Show text strings from an array.</summary>
         TextShowArray,
+
+        /// <summary>Move to next line and show text.</summary>
         TextNextLineShow,
+
+        /// <summary>Set word and character spacing, move to next line and show text.</summary>
         TextNextLineShowSpacing,
+
+        /// <summary>Set glyph width in type 3 font.</summary>
         SetCharWidth,
+
+        /// <summary>Establish text in the glyph cache.</summary>
         SetCacheDevice,
+
+        /// <summary>Set stroking color space by name.</summary>
         SetStrokingColorSpaceName,
+
+        /// <summary>Set nonstroking color space by name.</summary>
         SetNonstrokingColorSpaceName,
+
+        /// <summary>Set stroking color space to a device space.</summary>
         SetStrokingColorSpaceDevice,
+
+        /// <summary>Set stroking color space to an extended device space.</summary>
         SetStrokingColorSpaceDeviceExtended,
+
+        /// <summary>Set nonstroking color space to a device space.</summary>
         SetNonstrokingColorSpaceDevice,
+
+        /// <summary>Set nonstroking color space to an extended device space.</summary>
         SetNonstrokingColorSpaceDeviceExtended,
+
+        /// <summary>Set stroking gray level.</summary>
         SetStrokingColorSpaceGray,
+
+        /// <summary>Set nonstroking gray level.</summary>
         SetNonstrokingColorSpaceGray,
+
+        /// <summary>Set stroking RGB color.</summary>
         SetStrokingColorSpaceRGB,
+
+        /// <summary>Set nonstroking RGB color.</summary>
         SetNonstrokingColorSpaceRGB,
+
+        /// <summary>Set stroking CMYK color.</summary>
         SetStrokingColorSpaceCMYK,
+
+        /// <summary>Set nonstroking CMYK color.</summary>
         SetNonstrokingColorSpaceCMYK,
+
+        /// <summary>Paint with a shading pattern.</summary>
         ShadingPaint,
+
+        /// <summary>Begin an inline image object.</summary>
         BeginInlineImageObject,
+
+        /// <summary>Begin inline image data.</summary>
         BeginInlineImageData,
+
+        /// <summary>End the inline image object.</summary>
         EndInlineImageObject,
+
+        /// <summary>Invoke an external object.</summary>
         InvokeXObject,
+
+        /// <summary>Define a marked-content point.</summary>
         DefineMarkedContentPoint,
+
+        /// <summary>Define a marked-content point with property list.</summary>
         DefineMarkedContentPointWithPropertyList,
+
+        /// <summary>Begin a marked-content sequence.</summary>
         BeginMarkedContentSequence,
+
+        /// <summary>Begin a marked-content sequence with property list.</summary>
         BeginMarkedContentSequenceWithPropertyList,
+
+        /// <summary>End the marked-content sequence.</summary>
         EndMarkedContentSequence,
+
+        /// <summary>Begin a compatibility section.</summary>
         BeginCompatibilitySection,
+
+        /// <summary>End a compatibility section.</summary>
         EndCompatibilitySection
     };
 }

--- a/src/vanillapdf.net/PdfContents/PdfContentOperatorType.cs
+++ b/src/vanillapdf.net/PdfContents/PdfContentOperatorType.cs
@@ -9,79 +9,227 @@
         /// Undefined unitialized default value, triggers error when used
         /// </summary>
         Undefined = 0,
+
+        /// <summary>Unknown or unsupported operator.</summary>
         Unknown,
+
+        /// <summary>Set the current line width.</summary>
         LineWidth,
+
+        /// <summary>Set the line cap style.</summary>
         LineCap,
+
+        /// <summary>Set the line join style.</summary>
         LineJoin,
+
+        /// <summary>Set the miter limit.</summary>
         MiterLimit,
+
+        /// <summary>Define a dash pattern.</summary>
         DashPattern,
+
+        /// <summary>Specify color rendering intent.</summary>
         ColorRenderingIntent,
+
+        /// <summary>Set the flatness tolerance.</summary>
         Flatness,
+
+        /// <summary>Load a graphics state object.</summary>
         GraphicsState,
+
+        /// <summary>Save the graphics state.</summary>
         SaveGraphicsState,
+
+        /// <summary>Restore the graphics state.</summary>
         RestoreGraphicsState,
+
+        /// <summary>Modify the transformation matrix.</summary>
         TransformationMatrix,
+
+        /// <summary>Begin a new subpath.</summary>
         BeginSubpath,
+
+        /// <summary>Append a line segment.</summary>
         Line,
+
+        /// <summary>Append a complete Bézier curve.</summary>
         FullCurve,
+
+        /// <summary>Append the final control points of a Bézier curve.</summary>
         FinalCurve,
+
+        /// <summary>Append the initial control points of a Bézier curve.</summary>
         InitialCurve,
+
+        /// <summary>Close the current subpath.</summary>
         CloseSubpath,
+
+        /// <summary>Append a rectangle.</summary>
         Rectangle,
+
+        /// <summary>Stroke the current path.</summary>
         Stroke,
+
+        /// <summary>Close and stroke the current path.</summary>
         CloseAndStroke,
+
+        /// <summary>Fill path using the nonzero winding rule.</summary>
         FillPathNonzero,
+
+        /// <summary>Fill path for compatibility.</summary>
         FillPathCompatibility,
+
+        /// <summary>Fill path using the even-odd rule.</summary>
         FillPathEvenOdd,
+
+        /// <summary>Fill and then stroke path using the nonzero winding rule.</summary>
         FillStrokeNonzero,
+
+        /// <summary>Fill and then stroke path using the even-odd rule.</summary>
         FillStrokeEvenOdd,
+
+        /// <summary>Close, fill, and stroke path using the nonzero winding rule.</summary>
         CloseFillStrokeNonzero,
+
+        /// <summary>Close, fill, and stroke path using the even-odd rule.</summary>
         CloseFillStrokeEvenOdd,
+
+        /// <summary>End the path without filling or stroking.</summary>
         EndPath,
+
+        /// <summary>Modify clipping path using the nonzero winding rule.</summary>
         ClipPathNonzero,
+
+        /// <summary>Modify clipping path using the even-odd rule.</summary>
         ClipPathEvenOdd,
+
+        /// <summary>Begin a text object.</summary>
         BeginText,
+
+        /// <summary>End the current text object.</summary>
         EndText,
+
+        /// <summary>Set character spacing.</summary>
         CharacterSpacing,
+
+        /// <summary>Set word spacing.</summary>
         WordSpacing,
+
+        /// <summary>Set horizontal scaling.</summary>
         HorizontalScaling,
+
+        /// <summary>Set text leading.</summary>
         Leading,
+
+        /// <summary>Select the text font and size.</summary>
         TextFont,
+
+        /// <summary>Set text rendering mode.</summary>
         TextRenderingMode,
+
+        /// <summary>Set text rise.</summary>
         TextRise,
+
+        /// <summary>Move text position.</summary>
         TextTranslate,
+
+        /// <summary>Move text position and set leading.</summary>
         TextTranslateLeading,
+
+        /// <summary>Set text matrix.</summary>
         TextMatrix,
+
+        /// <summary>Move to start of next text line.</summary>
         TextNextLine,
+
+        /// <summary>Show a text string.</summary>
         TextShow,
+
+        /// <summary>Show text strings from an array.</summary>
         TextShowArray,
+
+        /// <summary>Move to next line and show text.</summary>
         TextNextLineShow,
+
+        /// <summary>Set word and character spacing, move to next line and show text.</summary>
         TextNextLineShowSpacing,
+
+        /// <summary>Set glyph width in type 3 font.</summary>
         SetCharWidth,
+
+        /// <summary>Establish text in the glyph cache.</summary>
         SetCacheDevice,
+
+        /// <summary>Set stroking color space by name.</summary>
         SetStrokingColorSpaceName,
+
+        /// <summary>Set nonstroking color space by name.</summary>
         SetNonstrokingColorSpaceName,
+
+        /// <summary>Set stroking color space to a device space.</summary>
         SetStrokingColorSpaceDevice,
+
+        /// <summary>Set stroking color space to an extended device space.</summary>
         SetStrokingColorSpaceDeviceExtended,
+
+        /// <summary>Set nonstroking color space to a device space.</summary>
         SetNonstrokingColorSpaceDevice,
+
+        /// <summary>Set nonstroking color space to an extended device space.</summary>
         SetNonstrokingColorSpaceDeviceExtended,
+
+        /// <summary>Set stroking gray level.</summary>
         SetStrokingColorSpaceGray,
+
+        /// <summary>Set nonstroking gray level.</summary>
         SetNonstrokingColorSpaceGray,
+
+        /// <summary>Set stroking RGB color.</summary>
         SetStrokingColorSpaceRGB,
+
+        /// <summary>Set nonstroking RGB color.</summary>
         SetNonstrokingColorSpaceRGB,
+
+        /// <summary>Set stroking CMYK color.</summary>
         SetStrokingColorSpaceCMYK,
+
+        /// <summary>Set nonstroking CMYK color.</summary>
         SetNonstrokingColorSpaceCMYK,
+
+        /// <summary>Paint with a shading pattern.</summary>
         ShadingPaint,
+
+        /// <summary>Begin an inline image object.</summary>
         BeginInlineImageObject,
+
+        /// <summary>Begin inline image data.</summary>
         BeginInlineImageData,
+
+        /// <summary>End the inline image object.</summary>
         EndInlineImageObject,
+
+        /// <summary>Invoke an external object.</summary>
         InvokeXObject,
+
+        /// <summary>Define a marked-content point.</summary>
         DefineMarkedContentPoint,
+
+        /// <summary>Define a marked-content point with property list.</summary>
         DefineMarkedContentPointWithPropertyList,
+
+        /// <summary>Begin a marked-content sequence.</summary>
         BeginMarkedContentSequence,
+
+        /// <summary>Begin a marked-content sequence with property list.</summary>
         BeginMarkedContentSequenceWithPropertyList,
+
+        /// <summary>End the marked-content sequence.</summary>
         EndMarkedContentSequence,
+
+        /// <summary>Begin a compatibility section.</summary>
         BeginCompatibilitySection,
+
+        /// <summary>End a compatibility section.</summary>
         EndCompatibilitySection
     };
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfAnnotationType.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfAnnotationType.cs
@@ -9,31 +9,83 @@
         /// Undefined unitialized default value, triggers error when used
         /// </summary>
         Undefined = 0,
+
+        /// <summary>Text annotation.</summary>
         Text,
+
+        /// <summary>Link annotation.</summary>
         Link,
+
+        /// <summary>Free text annotation.</summary>
         FreeText,
+
+        /// <summary>Line annotation.</summary>
         Line,
+
+        /// <summary>Square annotation.</summary>
         Square,
+
+        /// <summary>Circle annotation.</summary>
         Circle,
+
+        /// <summary>Polygon annotation.</summary>
         Polygon,
+
+        /// <summary>Polyline annotation.</summary>
         PolyLine,
+
+        /// <summary>Highlight annotation.</summary>
         Highlight,
+
+        /// <summary>Underline annotation.</summary>
         Underline,
+
+        /// <summary>Squiggly underline annotation.</summary>
         Squiggly,
+
+        /// <summary>Strikeout annotation.</summary>
         StrikeOut,
+
+        /// <summary>Rubber stamp annotation.</summary>
         RubberStamp,
+
+        /// <summary>Caret annotation.</summary>
         Caret,
+
+        /// <summary>Ink annotation.</summary>
         Ink,
+
+        /// <summary>Popup annotation.</summary>
         Popup,
+
+        /// <summary>File attachment annotation.</summary>
         FileAttachment,
+
+        /// <summary>Sound annotation.</summary>
         Sound,
+
+        /// <summary>Movie annotation.</summary>
         Movie,
+
+        /// <summary>Widget annotation.</summary>
         Widget,
+
+        /// <summary>Screen annotation.</summary>
         Screen,
+
+        /// <summary>Printer mark annotation.</summary>
         PrinterMark,
+
+        /// <summary>Trap network annotation.</summary>
         TrapNetwork,
+
+        /// <summary>Watermark annotation.</summary>
         Watermark,
+
+        /// <summary>3D annotation.</summary>
         TripleD,
+
+        /// <summary>Redaction annotation.</summary>
         Redaction,
     };
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfCharacterMapType.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfCharacterMapType.cs
@@ -9,7 +9,11 @@
         /// Undefined unitialized default value, triggers error when used
         /// </summary>
         Undefined = 0,
+
+        /// <summary>Embedded character map.</summary>
         Embedded,
+
+        /// <summary>Unicode character map.</summary>
         Unicode
     };
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFontType.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFontType.cs
@@ -20,15 +20,22 @@
         /// </summary>
         Type1,
 
+        /// <summary>Multiple master Type&nbsp;1 font.</summary>
         MMType1,
 
         /// <summary>
         /// A font that defines glyphs with streams of PDF graphics operators.
         /// </summary>
+        /// <summary>A font that defines glyphs with streams of PDF graphics operators.</summary>
         Type3,
 
+        /// <summary>A TrueType font.</summary>
         TrueType,
+
+        /// <summary>CIDFont Type&nbsp;0 font.</summary>
         CIDFontType0,
+
+        /// <summary>CIDFont Type&nbsp;2 font.</summary>
         CIDFontType2
     };
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfOutlineType.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfOutlineType.cs
@@ -9,7 +9,11 @@
         /// Undefined unitialized default value, triggers error when used
         /// </summary>
         Undefined = 0,
+
+        /// <summary>Root outline item.</summary>
         Outline,
+
+        /// <summary>Child outline item.</summary>
         Item,
     };
 }

--- a/src/vanillapdf.net/PdfSyntax/PdfImageColorSpaceType.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfImageColorSpaceType.cs
@@ -10,8 +10,13 @@
         /// </summary>
         Undefined = 0,
 
+        /// <summary>Device gray color space.</summary>
         GRAY,
+
+        /// <summary>Device RGB color space.</summary>
         RGB,
+
+        /// <summary>Device CMYK color space.</summary>
         CMYK,
     };
 }

--- a/src/vanillapdf.net/PdfSyntax/PdfObjectAttributeType.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfObjectAttributeType.cs
@@ -10,9 +10,16 @@
         /// </summary>
         Undefined = 0,
 
+        /// <summary>Attribute without specific semantics.</summary>
         Empty,
+
+        /// <summary>Attribute used to override serialization.</summary>
         SerializationOverride,
+
+        /// <summary>Identifier used for tracking purposes.</summary>
         TrackingIdentifier,
+
+        /// <summary>Attribute holding image metadata.</summary>
         ImageMetadata
     };
 }

--- a/src/vanillapdf.net/PdfSyntax/PdfXrefEntryType.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfXrefEntryType.cs
@@ -5,6 +5,9 @@
     /// </summary>
     public enum PdfXrefEntryType
     {
+        /// <summary>
+        /// Represents a null cross-reference entry.
+        /// </summary>
         Null = 0,
 
         /// <summary>

--- a/src/vanillapdf.net/PdfUtils/PdfLoggingSeverity.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfLoggingSeverity.cs
@@ -6,12 +6,26 @@
     public enum PdfLoggingSeverity
     {
         Undefined = 0,
+
+        /// <summary>Trace level logs.</summary>
         Trace,
+
+        /// <summary>Debug level logs.</summary>
         Debug,
+
+        /// <summary>Informational logs.</summary>
         Info,
+
+        /// <summary>Warning logs.</summary>
         Warning,
+
+        /// <summary>Error logs.</summary>
         Error,
+
+        /// <summary>Critical error logs.</summary>
         Critical,
+
+        /// <summary>Disable logging.</summary>
         Off
     };
 }

--- a/src/vanillapdf.net/PdfUtils/PdfVersion.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfVersion.cs
@@ -6,14 +6,32 @@
     public enum PdfVersion
     {
         Undefined = 0,
+
+        /// <summary>PDF 1.0.</summary>
         PdfVersion_10,
+
+        /// <summary>PDF 1.1.</summary>
         PdfVersion_11,
+
+        /// <summary>PDF 1.2.</summary>
         PdfVersion_12,
+
+        /// <summary>PDF 1.3.</summary>
         PdfVersion_13,
+
+        /// <summary>PDF 1.4.</summary>
         PdfVersion_14,
+
+        /// <summary>PDF 1.5.</summary>
         PdfVersion_15,
+
+        /// <summary>PDF 1.6.</summary>
         PdfVersion_16,
+
+        /// <summary>PDF 1.7.</summary>
         PdfVersion_17,
+
+        /// <summary>PDF 2.0.</summary>
         PdfVersion_20
     }
 }

--- a/src/vanillapdf.net/Utils/WindowsPlatformUtils.cs
+++ b/src/vanillapdf.net/Utils/WindowsPlatformUtils.cs
@@ -81,16 +81,37 @@ namespace vanillapdf.net.Utils
             [Flags]
             public enum LoadLibraryFlags : uint
             {
+                /// <summary>Do not resolve DLL references.</summary>
                 DONT_RESOLVE_DLL_REFERENCES = 0x00000001,
+
+                /// <summary>Ignore the code authorization level.</summary>
                 LOAD_IGNORE_CODE_AUTHZ_LEVEL = 0x00000010,
+
+                /// <summary>Load the DLL as a data file.</summary>
                 LOAD_LIBRARY_AS_DATAFILE = 0x00000002,
+
+                /// <summary>Load the DLL as a data file exclusively.</summary>
                 LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE = 0x00000040,
+
+                /// <summary>Load the DLL as an image resource.</summary>
                 LOAD_LIBRARY_AS_IMAGE_RESOURCE = 0x00000020,
+
+                /// <summary>Search the application directory.</summary>
                 LOAD_LIBRARY_SEARCH_APPLICATION_DIR = 0x00000200,
+
+                /// <summary>Use default search directories.</summary>
                 LOAD_LIBRARY_SEARCH_DEFAULT_DIRS = 0x00001000,
+
+                /// <summary>Search the directory of the DLL being loaded.</summary>
                 LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR = 0x00000100,
+
+                /// <summary>Search the system32 directory.</summary>
                 LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800,
+
+                /// <summary>Search user directories.</summary>
                 LOAD_LIBRARY_SEARCH_USER_DIRS = 0x00000400,
+
+                /// <summary>Alter the search path.</summary>
                 LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
             }
         }


### PR DESCRIPTION
## Summary
- add XML documentation comments for every enum value to silence build warnings

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603eeb0e90832bbee708a0e41f6e96