### PR TITLE
Simplify NuGet README

### DIFF
--- a/src/vanillapdf.net/README.md
+++ b/src/vanillapdf.net/README.md
@@ -1,90 +1,26 @@
 # Vanilla.PDF .NET
 
-[![NuGet Version](https://img.shields.io/nuget/v/vanillapdf.net.svg)](https://www.nuget.org/packages/vanillapdf.net/) [![CI Status](https://github.com/vanillapdf/vanillapdf.net/actions/workflows/ci.yml/badge.svg)](https://github.com/vanillapdf/vanillapdf.net/actions) [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+A lightweight .NET wrapper for the native [Vanilla.PDF](https://github.com/vanillapdf/vanillapdf) library. Use it to create, inspect and sign PDF documents with native performance on Windows, Linux and macOS.
 
-The official .NET binding for the core [Vanilla.PDF](https://github.com/vanillapdf/vanillapdf) C++17 library. Exposes a high-performance API to create, inspect, edit and sign PDF documents from any .NET Standard 2.0+ application.
+## Install
 
----
-
-## 📋 Table of Contents
-
-1. [Key Features](#key-features)
-2. [Getting Started](#getting-started)
-   - [Prerequisites](#prerequisites)
-   - [Installation](#installation)
-3. [Usage](#usage)
-4. [Samples & Local Docs](#samples--local-docs)
-5. [Building & Testing](#building--testing)
-6. [Contributing](#contributing)
-7. [Support](#support)
-8. [License](#license)
-
----
-
-## 🔑 Key Features
-- Cross-platform: Windows, Linux, macOS (.NET Standard 2.0+)
-- Native performance via a thin interop layer
-- Comprehensive PDF model with digital signatures
-- Lightweight with no large dependencies
-- Thread-safe API for concurrent use
-- CI/CD ready with GitHub Actions
-
----
-
-## 🚀 Getting Started
-
-### Prerequisites
-- .NET SDK 8.0 or newer
-
-### Installation
 ```bash
 dotnet add package vanillapdf.net
 ```
 
----
+## Quick start
 
-## ✍️ Usage
 ```csharp
 using vanillapdf.net.PdfSemantics;
 using vanillapdf.net.PdfSyntax;
 
 using var file = PdfFile.Open("input.pdf");
 file.Initialize();
-using var document = PdfDocument.OpenFile(file);
-using var catalog = document.GetCatalog();
-ulong pageCount = catalog.GetPages().GetPageCount();
-Console.WriteLine($"Pages: {pageCount}");
+using var doc = PdfDocument.OpenFile(file);
+Console.WriteLine(doc.GetCatalog().GetPages().GetPageCount());
 ```
 
----
+## Resources
 
-## 📁 Samples & Local Docs
-- Browse `samples/` for practical examples.
-- See the [CHANGELOG](https://github.com/vanillapdf/vanillapdf.net/blob/main/CHANGELOG.txt) and
-  [LICENSE](https://github.com/vanillapdf/vanillapdf.net/blob/main/LICENSE.txt).
-
----
-
-## 🚧 Building & Testing
-```bash
-dotnet restore
-dotnet build
-# from repository root to run tests
-cd .. && dotnet test vanillapdf.net.sln
-```
-
----
-
-## 👍 Contributing
-Contributions are welcome. Please open issues or pull requests on GitHub.
-
----
-
-## 💬 Support
-Use the [issue tracker](https://github.com/vanillapdf/vanillapdf.net/issues) or [contact us](https://vanillapdf.com/contact).
-
----
-
-## 📜 License
-Apache-2.0. See the [LICENSE](https://github.com/vanillapdf/vanillapdf.net/blob/main/LICENSE.txt) for details.
-
+- [Changelog](https://github.com/vanillapdf/vanillapdf.net/blob/main/CHANGELOG.txt)
+- [License](https://github.com/vanillapdf/vanillapdf.net/blob/main/LICENSE.txt)


### PR DESCRIPTION
## Summary
- simplify NuGet README by focusing on installation and quick usage
- drop invalid samples link

## Testing
- `dotnet test src/vanillapdf.net.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68604e08e20c832bbcf8fa79a4c89cc5