### PR TITLE
Add publish check to workflows

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -54,8 +54,12 @@ jobs:
             9.x
 
       # Build and test on current OS
-      - name: Build and test on ${{ matrix.os }}
-        run: dotnet test src/vanillapdf.net.sln --configuration Release --nologo
+        - name: Build and test on ${{ matrix.os }}
+          run: dotnet test src/vanillapdf.net.sln --configuration Release --nologo
+
+        - name: Verify publish on ${{ matrix.os }}
+          shell: bash
+          run: ./scripts/test_dotnet_publish.sh
 
   build-nuget:
     name: Build nuget package

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -44,3 +44,7 @@ jobs:
       # Build and test on current OS
       - name: Build and test on ${{ matrix.os }}
         run: dotnet test src/vanillapdf.net.sln --configuration Release --nologo
+
+      - name: Verify publish on ${{ matrix.os }}
+        shell: bash
+        run: ./scripts/test_dotnet_publish.sh

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ cd vanillapdf.net
 dotnet restore
 dotnet build
 dotnet test src/vanillapdf.net.sln
+# verify native libraries are published correctly
+./scripts/test_dotnet_publish.sh
 ```
 
 ---

--- a/scripts/test_dotnet_publish.sh
+++ b/scripts/test_dotnet_publish.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_rid() {
+    local os=$(uname -s)
+    local arch=$(uname -m)
+    case "$os" in
+        Linux)
+            case "$arch" in
+                x86_64) echo "linux-x64";;
+                aarch64) echo "linux-arm64";;
+                *) echo "Unsupported architecture $arch on Linux" >&2; return 1;;
+            esac
+            ;;
+        Darwin)
+            case "$arch" in
+                x86_64) echo "osx-x64";;
+                arm64) echo "osx-arm64";;
+                *) echo "Unsupported architecture $arch on macOS" >&2; return 1;;
+            esac
+            ;;
+        MINGW*|MSYS*|CYGWIN*|Windows_NT)
+            case "$arch" in
+                x86_64|amd64) echo "win-x64";;
+                i686|i386) echo "win-x86";;
+                *) echo "Unsupported architecture $arch on Windows" >&2; return 1;;
+            esac
+            ;;
+        *)
+            echo "Unsupported OS $os" >&2
+            return 1
+            ;;
+    esac
+}
+
+RID=$(get_rid)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+PROJECT="$REPO_ROOT/src/vanillapdf.net/vanillapdf.net.csproj"
+OUTPUT_DIR=$(mktemp -d)
+
+echo "Publishing $PROJECT for $RID..."
+
+dotnet publish "$PROJECT" -c Release -r "$RID" -o "$OUTPUT_DIR" --no-self-contained --nologo
+
+NATIVE_DIR="$OUTPUT_DIR/runtimes/$RID/native"
+
+if [ ! -d "$NATIVE_DIR" ]; then
+    echo "Missing native directory $NATIVE_DIR" >&2
+    exit 1
+fi
+
+if [ -z "$(ls -A "$NATIVE_DIR")" ]; then
+    echo "Native directory $NATIVE_DIR is empty" >&2
+    exit 1
+fi
+
+echo "dotnet publish produced native files in $NATIVE_DIR"
+
+rm -rf "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- run publish verification script as part of sanity-check jobs
- invoke script on Windows, Linux and macOS runners

## Testing
- `dotnet test src/vanillapdf.net.sln --no-build --verbosity normal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686596359fdc832b87d29e0fb6b202d0