### PR TITLE
Update macOS runners in CI matrices

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Summary
- replace deprecated macos-13 runner with macos-15-intel in CI matrices
- keep macos-latest entries for arm coverage in sanity checks and package builds

## Testing
- not run (CI configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ea889a90832ba21e983b13917d37)