### PR TITLE
Add .NET 10 support

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -56,6 +56,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
+            10.x
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -46,6 +46,7 @@ jobs:
           dotnet-version: |
             8.x
             9.x
+            10.x
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the official .NET binding for the [Vanilla.PDF](https://github.com/vanillapdf/vanillapdf) C++17 library. It provides a high-performance API for creating, inspecting, editing, and signing PDF documents via P/Invoke interop with native libraries.
+
+## Build and Test Commands
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Build the solution
+dotnet build src/vanillapdf.net.sln
+
+# Run all tests
+dotnet test src/vanillapdf.net.sln
+
+# Run tests with Release configuration (used in CI)
+dotnet test src/vanillapdf.net.sln --configuration Release
+
+# Run a single test by name
+dotnet test src/vanillapdf.net.sln --filter "FullyQualifiedName~TestMethodName"
+
+# Verify native library publishing (cross-platform script)
+./scripts/test_dotnet_publish.sh
+```
+
+## Architecture
+
+### Native Interop Layer
+
+The library wraps a native C++17 library (`vanillapdf` NuGet package) using P/Invoke. Key components:
+
+- **`Utils/LibraryInstance.cs`**: Manages native library loading per platform (Windows/Linux/macOS). Provides `GetFunction<T>()` to resolve native symbols at runtime.
+- **`Utils/PlatformUtils.cs`**: Platform-specific implementations for loading native libraries (`WindowsPlatformUtils`, `LinuxPlatformUtils`, `MacPlatformUtils`).
+- **`Utils/SafeHandles/`**: SafeHandle wrappers for native pointers, ensuring proper cleanup.
+
+### Object Hierarchy
+
+All managed objects inherit from `PdfUnknown` (in `PdfUtils/`), which implements COM-style reference counting (`AddRef`/`Release`) and `IDisposable`. Objects must be disposed to release native resources.
+
+### Namespace Organization
+
+- **`vanillapdf.net.PdfSyntax`**: Low-level PDF structure (`PdfFile`, `PdfObject`, `PdfDictionaryObject`, `PdfArrayObject`, etc.). Use `PdfFile.Open()` to open files and `Initialize()` to parse xref tables.
+- **`vanillapdf.net.PdfSemantics`**: High-level PDF model (`PdfDocument`, `PdfCatalog`, `PdfPage`, `PdfAnnotation`, etc.). Built on top of syntax layer.
+- **`vanillapdf.net.PdfContents`**: Content stream parsing (`PdfContentParser`, `PdfContentInstruction`, text/font operations).
+- **`vanillapdf.net.PdfUtils`**: Utilities including streams (`PdfInputStream`, `PdfOutputStream`), buffers, signing keys, and logging.
+
+### Typical Usage Pattern
+
+```csharp
+using var file = PdfFile.Open("input.pdf");
+file.Initialize();  // Required: parses cross-reference tables
+using var document = PdfDocument.OpenFile(file);
+using var catalog = document.GetCatalog();
+```
+
+### Test Project
+
+Tests use NUnit (`vanillapdf.net.nunit` project). The `OneTimeSetup.cs` initializes the native library via `LibraryInstance.Initialize(TestContext.CurrentContext.TestDirectory)`. Test resources are in `src/vanillapdf.net.nunit/Resources/`.
+
+## Target Frameworks
+
+- Main library: .NET Standard 2.0 (broad compatibility)
+- Test project: .NET 8.0, .NET 9.0, and .NET 10.0

--- a/src/vanillapdf.net.nunit/vanillapdf.net.nunit.csproj
+++ b/src/vanillapdf.net.nunit/vanillapdf.net.nunit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/vanillapdf.net/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/vanillapdf.net/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121. -->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\netstandard2.0\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add `net10.0` target framework to the test project
- Update CI workflows (`sanity-check.yml`, `build-nuget.yml`) to install .NET 10 SDK
- Add `CLAUDE.md` documentation for Claude Code

## Test plan
- [x] Verify CI builds pass on all platforms (ubuntu-latest, windows-latest, macos-15-intel, macos-latest)
- [x] Verify tests run successfully on .NET 8, .NET 9, and .NET 10

🤖 Generated with [Claude Code](https://claude.ai/claude-code)