### PR TITLE
Add snupkg symbol package support with Source Link

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -18,7 +18,9 @@
     <PackageIcon>vanilla_logo.png</PackageIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>portable</DebugType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -55,6 +57,7 @@
 
   <ItemGroup>
     <PackageReference Include="vanillapdf" Version="2.2.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Enable `.snupkg` symbol package generation for better debugging experience
- Add Microsoft.SourceLink.GitHub for source-level debugging support
- Enable portable PDB format and embed untracked sources

## Changes
- Set `IncludeSymbols` to `True`
- Set `DebugType` to `portable`
- Add `EmbedUntrackedSources` for complete source mapping
- Add `Microsoft.SourceLink.GitHub` package reference

## Benefits
- Consumers can step through library source code during debugging
- Better stack traces with source file and line information
- Automatic source download from GitHub in debuggers

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)