### PR TITLE
Add PdfDocumentInfo bindings for reading document metadata

### DIFF
--- a/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentInfoTest.cs
+++ b/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentInfoTest.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.IO;
+using vanillapdf.net.PdfSemantics;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+
+namespace vanillapdf.net.nunit.PdfSemantics
+{
+    [TestFixture]
+    public class PdfDocumentInfoTest
+    {
+        [Test]
+        public void TestGetDocumentInfo()
+        {
+            string sourceFile = Path.Combine("Resources", "19005-1_FAQ.PDF");
+
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(sourceFile);
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var documentInfo = document.GetDocumentInfo();
+
+            ClassicAssert.IsNotNull(documentInfo);
+        }
+
+        [Test]
+        public void TestDocumentInfoProperties()
+        {
+            string sourceFile = Path.Combine("Resources", "19005-1_FAQ.PDF");
+
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(sourceFile);
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var documentInfo = document.GetDocumentInfo();
+
+            // Properties may be null if not set in the document
+            var title = documentInfo.Title;
+            var author = documentInfo.Author;
+            var subject = documentInfo.Subject;
+            var keywords = documentInfo.Keywords;
+            var creator = documentInfo.Creator;
+            var producer = documentInfo.Producer;
+            var creationDate = documentInfo.CreationDate;
+            var modificationDate = documentInfo.ModificationDate;
+
+            // At least verify we can access the properties without exceptions
+            ClassicAssert.IsNotNull(documentInfo);
+        }
+
+        [Test]
+        public void TestStability()
+        {
+            string sourceFile = Path.Combine("Resources", "19005-1_FAQ.PDF");
+
+            for (int i = 0; i < OneTimeSetup.STABILITY_REPEAT_COUNT; ++i) {
+                using var sourceStream = PdfInputOutputStream.CreateFromFile(sourceFile);
+                using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+                file.Initialize();
+
+                using var document = PdfDocument.OpenFile(file);
+                using var documentInfo = document.GetDocumentInfo();
+            }
+
+            GC.Collect();
+        }
+    }
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfDocument.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDocument.cs
@@ -171,6 +171,20 @@ namespace vanillapdf.net.PdfSemantics
             }
         }
 
+        /// <summary>
+        /// Get document information dictionary containing metadata about the PDF document.
+        /// </summary>
+        /// <returns>Handle to existing \ref PdfDocumentInfo instance on success, throws exception on failure</returns>
+        public PdfDocumentInfo GetDocumentInfo()
+        {
+            UInt32 result = NativeMethods.Document_GetDocumentInfo(Handle, out var data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfDocumentInfo(data);
+        }
+
         private protected override void DisposeCustomHandle()
         {
             base.DisposeCustomHandle();
@@ -191,6 +205,7 @@ namespace vanillapdf.net.PdfSemantics
 
             public static AddEncryptionDelgate Document_AddEncryption = LibraryInstance.GetFunction<AddEncryptionDelgate>("Document_AddEncryption");
             public static RemoveEncryptionDelgate Document_RemoveEncryption = LibraryInstance.GetFunction<RemoveEncryptionDelgate>("Document_RemoveEncryption");
+            public static GetDocumentInfoDelgate Document_GetDocumentInfo = LibraryInstance.GetFunction<GetDocumentInfoDelgate>("Document_GetDocumentInfo");
 
             [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
             public delegate UInt32 OpenDelgate(string filename, out PdfDocumentSafeHandle data);
@@ -224,6 +239,9 @@ namespace vanillapdf.net.PdfSemantics
 
             [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
             public delegate UInt32 RemoveEncryptionDelgate(PdfDocumentSafeHandle handle);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetDocumentInfoDelgate(PdfDocumentSafeHandle handle, out PdfDocumentInfoSafeHandle data);
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfDocumentInfo.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDocumentInfo.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+using vanillapdf.net.Utils;
+
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// Represents the document information dictionary containing metadata about the PDF document.
+    /// </summary>
+    public class PdfDocumentInfo : PdfUnknown
+    {
+        internal PdfDocumentInfoSafeHandle Handle { get; }
+
+        internal PdfDocumentInfo(PdfDocumentInfoSafeHandle handle) : base(handle)
+        {
+            Handle = handle;
+        }
+
+        static PdfDocumentInfo()
+        {
+            RuntimeHelpers.RunClassConstructor(typeof(NativeMethods).TypeHandle);
+            RuntimeHelpers.RunClassConstructor(typeof(PdfDocumentInfoSafeHandle).TypeHandle);
+        }
+
+        // TODO: Add setters when native API is available
+
+        /// <summary>
+        /// The document's title.
+        /// </summary>
+        public PdfStringObject Title => GetTitle();
+
+        /// <summary>
+        /// The name of the person who created the document.
+        /// </summary>
+        public PdfStringObject Author => GetAuthor();
+
+        /// <summary>
+        /// The subject of the document.
+        /// </summary>
+        public PdfStringObject Subject => GetSubject();
+
+        /// <summary>
+        /// Keywords associated with the document.
+        /// </summary>
+        public PdfStringObject Keywords => GetKeywords();
+
+        /// <summary>
+        /// The name of the application that created the original document.
+        /// </summary>
+        public PdfStringObject Creator => GetCreator();
+
+        /// <summary>
+        /// The name of the application that produced the PDF.
+        /// </summary>
+        public PdfStringObject Producer => GetProducer();
+
+        /// <summary>
+        /// The date and time the document was created.
+        /// </summary>
+        public PdfDate CreationDate => GetCreationDate();
+
+        /// <summary>
+        /// The date and time the document was most recently modified.
+        /// </summary>
+        public PdfDate ModificationDate => GetModificationDate();
+
+        #region Private Methods
+
+        private PdfStringObject GetTitle()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetTitle(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetAuthor()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetAuthor(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetSubject()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetSubject(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetKeywords()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetKeywords(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetCreator()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetCreator(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetProducer()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetProducer(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfDate GetCreationDate()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetCreationDate(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfDate(data);
+        }
+
+        private PdfDate GetModificationDate()
+        {
+            UInt32 result = NativeMethods.DocumentInfo_GetModificationDate(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfDate(data);
+        }
+
+        #endregion
+
+        private protected override void DisposeCustomHandle()
+        {
+            base.DisposeCustomHandle();
+            Handle?.Dispose();
+        }
+
+        private static class NativeMethods
+        {
+            public static GetTitleDelegate DocumentInfo_GetTitle = LibraryInstance.GetFunction<GetTitleDelegate>("DocumentInfo_GetTitle");
+            public static GetAuthorDelegate DocumentInfo_GetAuthor = LibraryInstance.GetFunction<GetAuthorDelegate>("DocumentInfo_GetAuthor");
+            public static GetSubjectDelegate DocumentInfo_GetSubject = LibraryInstance.GetFunction<GetSubjectDelegate>("DocumentInfo_GetSubject");
+            public static GetKeywordsDelegate DocumentInfo_GetKeywords = LibraryInstance.GetFunction<GetKeywordsDelegate>("DocumentInfo_GetKeywords");
+            public static GetCreatorDelegate DocumentInfo_GetCreator = LibraryInstance.GetFunction<GetCreatorDelegate>("DocumentInfo_GetCreator");
+            public static GetProducerDelegate DocumentInfo_GetProducer = LibraryInstance.GetFunction<GetProducerDelegate>("DocumentInfo_GetProducer");
+            public static GetCreationDateDelegate DocumentInfo_GetCreationDate = LibraryInstance.GetFunction<GetCreationDateDelegate>("DocumentInfo_GetCreationDate");
+            public static GetModificationDateDelegate DocumentInfo_GetModificationDate = LibraryInstance.GetFunction<GetModificationDateDelegate>("DocumentInfo_GetModificationDate");
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetTitleDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetAuthorDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetSubjectDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetKeywordsDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetCreatorDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetProducerDelegate(PdfDocumentInfoSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetCreationDateDelegate(PdfDocumentInfoSafeHandle handle, out PdfDateSafeHandle data);
+
+            [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+            public delegate UInt32 GetModificationDateDelegate(PdfDocumentInfoSafeHandle handle, out PdfDateSafeHandle data);
+        }
+    }
+}

--- a/src/vanillapdf.net/Utils/MiscUtils.cs
+++ b/src/vanillapdf.net/Utils/MiscUtils.cs
@@ -75,6 +75,7 @@ namespace vanillapdf.net.Utils
             RuntimeHelpers.RunClassConstructor(typeof(PdfRectangle).TypeHandle);
 
             RuntimeHelpers.RunClassConstructor(typeof(PdfDocument).TypeHandle);
+            RuntimeHelpers.RunClassConstructor(typeof(PdfDocumentInfo).TypeHandle);
             RuntimeHelpers.RunClassConstructor(typeof(PdfDocumentSignatureSettings).TypeHandle);
 
             RuntimeHelpers.RunClassConstructor(typeof(PdfCatalog).TypeHandle);

--- a/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
+++ b/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
@@ -180,6 +180,41 @@ namespace vanillapdf.net.Utils
         }
     }
 
+    internal sealed class PdfDocumentInfoSafeHandle : PdfSafeHandle
+    {
+        private static readonly GenericReleaseDelgate StaticReleaseDelegate = LibraryInstance.GetFunction<GenericReleaseDelgate>("DocumentInfo_Release");
+        protected override GenericReleaseDelgate ReleaseDelegate => StaticReleaseDelegate;
+
+        private static readonly ConvertToUnknownDelegate Convert_ToUnknown = LibraryInstance.GetFunction<ConvertToUnknownDelegate>("DocumentInfo_ToUnknown");
+        private static readonly ConvertFromUnknownDelegate Convert_FromUnknown = LibraryInstance.GetFunction<ConvertFromUnknownDelegate>("DocumentInfo_FromUnknown");
+
+        [UnmanagedFunctionPointer(LibraryCallingConvention)]
+        private delegate UInt32 ConvertToUnknownDelegate(PdfDocumentInfoSafeHandle handle, out PdfUnknownSafeHandle data);
+
+        [UnmanagedFunctionPointer(MiscUtils.LibraryCallingConvention)]
+        private delegate UInt32 ConvertFromUnknownDelegate(PdfUnknownSafeHandle handle, out PdfDocumentInfoSafeHandle data);
+
+        public static implicit operator PdfUnknownSafeHandle(PdfDocumentInfoSafeHandle handle)
+        {
+            UInt32 result = Convert_ToUnknown(handle, out PdfUnknownSafeHandle data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        public static implicit operator PdfDocumentInfoSafeHandle(PdfUnknownSafeHandle handle)
+        {
+            UInt32 result = Convert_FromUnknown(handle, out PdfDocumentInfoSafeHandle data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+    }
+
     internal sealed class PdfDocumentEncryptionSettingsSafeHandle : PdfSafeHandle
     {
         private static readonly GenericReleaseDelgate StaticReleaseDelegate = LibraryInstance.GetFunction<GenericReleaseDelgate>("DocumentEncryptionSettings_Release");


### PR DESCRIPTION
## Summary
- Adds `PdfDocumentInfo` class with read-only properties for accessing PDF document metadata
- Properties include: Title, Author, Subject, Keywords, Creator, Producer, CreationDate, ModificationDate
- Adds `GetDocumentInfo()` method to `PdfDocument` class
- Includes unit tests for the new functionality

Note: Setters are not yet implemented (TODO comment added) - waiting for native API support.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)