### PR TITLE
Update copyright year to 2026

### DIFF
--- a/doc/src/input/index.dox
+++ b/doc/src/input/index.dox
@@ -12,6 +12,6 @@ Next be sure to take a look at \ref page_overview, which contains all the necess
 
 In case of any questions, do not hesitate to [contact us](mailto:info@vanillapdf.com).
 
-Copyright &copy; 2018 by [Vanilla.PDF Labs](mailto:info@vanillapdf.com)
+Copyright &copy; 2018-2026 by [Vanilla.PDF Labs](mailto:info@vanillapdf.com)
 
 */

--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl></RepositoryUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Description>Vanilla.PDF is a cross-platform SDK for creating and modifying PDF documents</Description>
-    <Copyright>Copyright 2018-2025 Vanilla.PDF Labs s.r.o.</Copyright>
+    <Copyright>Copyright 2018-2026 Vanilla.PDF Labs s.r.o.</Copyright>
     <PackageTags>pdf parsing sign</PackageTags>
     <PackageIcon>vanilla_logo.png</PackageIcon>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary
- Update copyright year from 2018-2025 to 2018-2026 in NuGet package metadata
- Update copyright year from 2018 to 2018-2026 in documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)