### PR TITLE
Include snupkg symbol packages in build artifacts

### DIFF
--- a/.github/workflows/build-nuget.yml
+++ b/.github/workflows/build-nuget.yml
@@ -102,4 +102,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: vanillapdf.net
-          path: nupkgs/*.nupkg
+          path: |
+            nupkgs/*.nupkg
+            nupkgs/*.snupkg


### PR DESCRIPTION
## Summary

- Include `*.snupkg` symbol packages in the build artifact upload
- Enables automatic symbol package publishing to NuGet.org

Previously, snupkg files were generated by `dotnet pack` but discarded because they weren't uploaded to the artifact.

## Test plan

- [x] Artifact upload includes both nupkg and snupkg patterns

🤖 Generated with [Claude Code](https://claude.ai/claude-code)