### PR TITLE
Change default UpgradePolicy from ResolveOnly to Single

### DIFF
--- a/src/vanillapdf.net/Utils/LibraryInstance.cs
+++ b/src/vanillapdf.net/Utils/LibraryInstance.cs
@@ -39,11 +39,13 @@ namespace vanillapdf.net.Utils
     /// </summary>
     public static class LibraryInstance
     {
-        private static volatile UpgradePolicy _upgradePolicy = UpgradePolicy.ResolveOnly;
+        // TODO: Review default upgrade policy for 3.0 — consider ResolveOnly as the default
+        // to encourage explicit Is<T>/As<T> usage and reduce unnecessary allocations.
+        private static volatile UpgradePolicy _upgradePolicy = UpgradePolicy.Single;
 
         /// <summary>
         /// Gets or sets the upgrade policy for accessor methods.
-        /// Default is <see cref="UpgradePolicy.ResolveOnly"/>.
+        /// Default is <see cref="UpgradePolicy.Single"/>.
         /// </summary>
         public static UpgradePolicy UpgradePolicy
         {


### PR DESCRIPTION
## Summary

- Change the default `UpgradePolicy` from `ResolveOnly` to `Single` to preserve backward-compatible behavior matching the type resolution depth of the previous release
- Add TODO comment to reconsider default for 3.0, where `ResolveOnly` may be more appropriate to encourage explicit `Is<T>/As<T>` usage and reduce allocations

## Test plan

- [x] All 16 UpgradePolicy tests pass across net8.0, net9.0, net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)