### PR TITLE
Bump vanillapdf native dependency to 2.2.1

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -68,7 +68,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.2.0" />
+    <PackageReference Include="vanillapdf" Version="2.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Update `vanillapdf` native NuGet package from 2.2.0 to 2.2.1
- Includes `ToUnknown` support needed for the signature verification feature branch

## Test plan
- [x] Build succeeds with new dependency
- [x] CI passes on all target frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)