### PR TITLE
Improve NativeAOT readiness with stricter build analysis

### DIFF
--- a/src/vanillapdf.net/Utils/CustomMarshallers.cs
+++ b/src/vanillapdf.net/Utils/CustomMarshallers.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if NETSTANDARD2_0
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -66,3 +68,5 @@ namespace vanillapdf.net.Utils
         }
     }
 }
+
+#endif

--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -8,6 +8,8 @@
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsTrimmable>
     <EnableTrimAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</EnableAotAnalyzer>
+    <TreatWarningsAsErrors Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</TreatWarningsAsErrors>
     <PublishAot Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishAot>
     <PublishTrimmed Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishTrimmed>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
## Summary
- Gate `Utf8StringMarshaler` (`ICustomMarshaler`) behind `#if NETSTANDARD2_0` so it is excluded from the net8.0+ build where `LibraryImport` with `StringMarshalling.Utf8` is used instead
- Enable `EnableAotAnalyzer` and `TreatWarningsAsErrors` for net8.0+ targets to catch AOT/trimming regressions at build time

## Test plan
- [x] Verify `dotnet build` succeeds with 0 warnings/errors for both netstandard2.0 and net8.0
- [x] Verify `dotnet test` passes on all target frameworks
- [x] Verify `scripts/test_native_aot.sh` AOT publish still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)