### PR TITLE
Bump vanillapdf native dependency to 2.3.0-beta.1

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -14,7 +14,7 @@
     <PublishTrimmed Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishTrimmed>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <VersionPrefix>2.3.0-alpha.1</VersionPrefix>
+    <VersionPrefix>2.3.0-beta.1</VersionPrefix>
     <Title>vanillapdf.net</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>
     <PackageProjectUrl>https://vanillapdf.com/</PackageProjectUrl>
@@ -70,7 +70,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.3.0-alpha.1" />
+    <PackageReference Include="vanillapdf" Version="2.3.0-beta.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Updates the native `vanillapdf` package reference from 2.3.0-alpha.1 to 2.3.0-beta.1
- Bumps the binding `VersionPrefix` to 2.3.0-beta.1 to match, following the pattern from #70

## Upstream highlights relevant to this binding
- Signing engine migrated from legacy PKCS#7 to the OpenSSL CMS API, with corrected AES-CBC PKCS#7 padding
- `PdfTextString` encoding detection and UTF-8/UTF-16 conversion (`StringObjectPtr` redesign)
- Fixed data races in Dictionary/Array/IndirectReference hashing and Document catalog lazy initialization
- Flat page cache in `PageTree`, eliminating O(N²) sequential page access
- New `win-arm64` native binaries in the NuGet package

## Test plan
- [x] `dotnet build` Release: 0 warnings, 0 errors
- [x] `dotnet test` Release: all 228 tests pass on net9.0 and net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)