### PR TITLE
Add DigitalSignature metadata getters and ByteRange API

### DIFF
--- a/src/vanillapdf.net.nunit/PdfUtils/SignatureVerificationTest.cs
+++ b/src/vanillapdf.net.nunit/PdfUtils/SignatureVerificationTest.cs
@@ -312,23 +312,23 @@ namespace vanillapdf.net.nunit.PdfUtils
             using var sig = FindFirstDigitalSignature(document);
             ClassicAssert.IsNotNull(sig);
 
-            using var name = sig.GetName();
+            using var name = sig.Name;
             ClassicAssert.IsNotNull(name);
             ClassicAssert.AreEqual("Test Signer", name.Value.StringData);
 
-            using var location = sig.GetLocation();
+            using var location = sig.Location;
             ClassicAssert.IsNotNull(location);
             ClassicAssert.AreEqual("Test City", location.Value.StringData);
 
-            using var reason = sig.GetReason();
+            using var reason = sig.Reason;
             ClassicAssert.IsNotNull(reason);
             ClassicAssert.AreEqual("Integration testing", reason.Value.StringData);
 
-            using var signingTime = sig.GetSigningTime();
+            using var signingTime = sig.SigningTime;
             ClassicAssert.IsNotNull(signingTime);
             ClassicAssert.GreaterOrEqual(signingTime.Year, 2026);
 
-            using var contents = sig.GetContents();
+            using var contents = sig.Contents;
             ClassicAssert.IsNotNull(contents);
             ClassicAssert.Greater(contents.Value.Data.Length, 0);
         }
@@ -347,10 +347,10 @@ namespace vanillapdf.net.nunit.PdfUtils
             using var sig = FindFirstDigitalSignature(document);
             ClassicAssert.IsNotNull(sig);
 
-            ClassicAssert.IsNull(sig.GetName());
-            ClassicAssert.IsNull(sig.GetLocation());
-            ClassicAssert.IsNull(sig.GetReason());
-            ClassicAssert.IsNull(sig.GetContactInfo());
+            ClassicAssert.IsNull(sig.Name);
+            ClassicAssert.IsNull(sig.Location);
+            ClassicAssert.IsNull(sig.Reason);
+            ClassicAssert.IsNull(sig.ContactInfo);
         }
 
         [Test]
@@ -367,7 +367,7 @@ namespace vanillapdf.net.nunit.PdfUtils
             using var sig = FindFirstDigitalSignature(document);
             ClassicAssert.IsNotNull(sig);
 
-            using var byteRange = sig.GetByteRange();
+            using var byteRange = sig.ByteRange;
             ClassicAssert.IsNotNull(byteRange);
 
             UInt64 rangeCount = byteRange.GetSize();
@@ -377,8 +377,8 @@ namespace vanillapdf.net.nunit.PdfUtils
             Int64 previousEnd = 0;
             for (UInt64 i = 0; i < rangeCount; i++) {
                 using var range = byteRange.GetValueAt(i);
-                using var offset = range.GetOffset();
-                using var length = range.GetLength();
+                using var offset = range.Offset;
+                using var length = range.Length;
 
                 ClassicAssert.GreaterOrEqual(offset.IntegerValue, previousEnd);
                 ClassicAssert.GreaterOrEqual(length.IntegerValue, 0);

--- a/src/vanillapdf.net.nunit/PdfUtils/SignatureVerificationTest.cs
+++ b/src/vanillapdf.net.nunit/PdfUtils/SignatureVerificationTest.cs
@@ -295,6 +295,99 @@ namespace vanillapdf.net.nunit.PdfUtils
 
         #endregion
 
+        #region DigitalSignature Metadata
+
+        [Test]
+        public void TestDigitalSignatureMetadata()
+        {
+            string sourceFile = Path.Combine("Resources", "Granizo.pdf");
+
+            using var signedStream = PdfInputOutputStream.CreateFromMemory();
+            using var currentTime = PdfDate.CreateCurrent();
+            SignDocumentToStream(sourceFile, signedStream, "Test Signer", "Test City", "Integration testing", currentTime);
+
+            using var pdfFile = PdfFile.OpenStream(signedStream, "signedStream");
+            pdfFile.Initialize();
+            using var document = PdfDocument.OpenFile(pdfFile);
+            using var sig = FindFirstDigitalSignature(document);
+            ClassicAssert.IsNotNull(sig);
+
+            using var name = sig.GetName();
+            ClassicAssert.IsNotNull(name);
+            ClassicAssert.AreEqual("Test Signer", name.Value.StringData);
+
+            using var location = sig.GetLocation();
+            ClassicAssert.IsNotNull(location);
+            ClassicAssert.AreEqual("Test City", location.Value.StringData);
+
+            using var reason = sig.GetReason();
+            ClassicAssert.IsNotNull(reason);
+            ClassicAssert.AreEqual("Integration testing", reason.Value.StringData);
+
+            using var signingTime = sig.GetSigningTime();
+            ClassicAssert.IsNotNull(signingTime);
+            ClassicAssert.GreaterOrEqual(signingTime.Year, 2026);
+
+            using var contents = sig.GetContents();
+            ClassicAssert.IsNotNull(contents);
+            ClassicAssert.Greater(contents.Value.Data.Length, 0);
+        }
+
+        [Test]
+        public void TestDigitalSignatureMetadataMissing()
+        {
+            string sourceFile = Path.Combine("Resources", "Granizo.pdf");
+
+            using var signedStream = PdfInputOutputStream.CreateFromMemory();
+            SignDocumentToStream(sourceFile, signedStream);
+
+            using var pdfFile = PdfFile.OpenStream(signedStream, "signedStream");
+            pdfFile.Initialize();
+            using var document = PdfDocument.OpenFile(pdfFile);
+            using var sig = FindFirstDigitalSignature(document);
+            ClassicAssert.IsNotNull(sig);
+
+            ClassicAssert.IsNull(sig.GetName());
+            ClassicAssert.IsNull(sig.GetLocation());
+            ClassicAssert.IsNull(sig.GetReason());
+            ClassicAssert.IsNull(sig.GetContactInfo());
+        }
+
+        [Test]
+        public void TestDigitalSignatureByteRange()
+        {
+            string sourceFile = Path.Combine("Resources", "Granizo.pdf");
+
+            using var signedStream = PdfInputOutputStream.CreateFromMemory();
+            SignDocumentToStream(sourceFile, signedStream);
+
+            using var pdfFile = PdfFile.OpenStream(signedStream, "signedStream");
+            pdfFile.Initialize();
+            using var document = PdfDocument.OpenFile(pdfFile);
+            using var sig = FindFirstDigitalSignature(document);
+            ClassicAssert.IsNotNull(sig);
+
+            using var byteRange = sig.GetByteRange();
+            ClassicAssert.IsNotNull(byteRange);
+
+            UInt64 rangeCount = byteRange.GetSize();
+            ClassicAssert.Greater(rangeCount, 0);
+
+            // Ranges must be ascending and non-overlapping
+            Int64 previousEnd = 0;
+            for (UInt64 i = 0; i < rangeCount; i++) {
+                using var range = byteRange.GetValueAt(i);
+                using var offset = range.GetOffset();
+                using var length = range.GetLength();
+
+                ClassicAssert.GreaterOrEqual(offset.IntegerValue, previousEnd);
+                ClassicAssert.GreaterOrEqual(length.IntegerValue, 0);
+                previousEnd = offset.IntegerValue + length.IntegerValue;
+            }
+        }
+
+        #endregion
+
         #region Stability
 
         [Test]
@@ -333,6 +426,69 @@ namespace vanillapdf.net.nunit.PdfUtils
             signSettings.SigningKey = key;
             signSettings.Digest = PdfMessageDigestAlgorithmType.SHA256;
             document.Sign(destFile, signSettings);
+        }
+
+        private static void SignDocumentToStream(string sourceFile, PdfInputOutputStream signedStream)
+        {
+            using var file = PdfFile.Open(sourceFile);
+            file.Initialize();
+            using var document = PdfDocument.OpenFile(file);
+            using var destFile = PdfFile.CreateStream(signedStream, "signedStream");
+            using var signSettings = PdfDocumentSignatureSettings.Create();
+            using var keyBuffer = PdfBuffer.Create();
+            keyBuffer.Data = Convert.FromBase64String(PKCS12_KEY_BASE64);
+            using var key = PdfPKCS12Key.CreateFromBuffer(keyBuffer, null);
+
+            signSettings.SigningKey = key;
+            signSettings.Digest = PdfMessageDigestAlgorithmType.SHA256;
+            document.Sign(destFile, signSettings);
+        }
+
+        private static void SignDocumentToStream(string sourceFile, PdfInputOutputStream signedStream, string name, string location, string reason, PdfDate signingTime)
+        {
+            using var file = PdfFile.Open(sourceFile);
+            file.Initialize();
+            using var document = PdfDocument.OpenFile(file);
+            using var destFile = PdfFile.CreateStream(signedStream, "signedStream");
+            using var signSettings = PdfDocumentSignatureSettings.Create();
+            using var keyBuffer = PdfBuffer.Create();
+            keyBuffer.Data = Convert.FromBase64String(PKCS12_KEY_BASE64);
+            using var key = PdfPKCS12Key.CreateFromBuffer(keyBuffer, null);
+
+            using var nameObject = PdfLiteralStringObject.CreateFromDecodedString(name);
+            using var locationObject = PdfLiteralStringObject.CreateFromDecodedString(location);
+            using var reasonObject = PdfLiteralStringObject.CreateFromDecodedString(reason);
+
+            signSettings.SigningKey = key;
+            signSettings.Digest = PdfMessageDigestAlgorithmType.SHA256;
+            signSettings.Name = nameObject;
+            signSettings.Location = locationObject;
+            signSettings.Reason = reasonObject;
+            signSettings.SigningTime = signingTime;
+            document.Sign(destFile, signSettings);
+        }
+
+        private static PdfDigitalSignature FindFirstDigitalSignature(PdfDocument document)
+        {
+            using var catalog = document.GetCatalog();
+            using var acroForm = catalog.GetAcroForm();
+            using var fields = acroForm.GetFields();
+
+            UInt64 count = fields.GetSize();
+            for (UInt64 i = 0; i < count; i++) {
+                using var field = fields.GetValueAt(i);
+                if (field.GetFieldType() != PdfFieldType.Signature) {
+                    continue;
+                }
+
+                using var sigField = PdfSignatureField.FromField(field);
+                var sig = sigField.GetValue();
+                if (sig != null) {
+                    return sig;
+                }
+            }
+
+            return null;
         }
 
         private static SignatureVerificationResult VerifySignedDocument(string signedFile, TrustedCertificateStore store, SignatureVerificationSettings settings = null)

--- a/src/vanillapdf.net/Interop/NativeMethods.Semantics.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Semantics.DllImport.cs
@@ -279,7 +279,56 @@ namespace vanillapdf.net.Interop
         #region DigitalSignature
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetContactInfo(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetReason(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetLocation(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetSigningTime(PdfDigitalSignatureSafeHandle handle, out PdfDateSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetName(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetRevision(PdfDigitalSignatureSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetCertificate(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetContents(PdfDigitalSignatureSafeHandle handle, out PdfHexadecimalStringObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 DigitalSignature_GetByteRange(PdfDigitalSignatureSafeHandle handle, out PdfByteRangeCollectionSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 DigitalSignature_Release(IntPtr handle);
+
+        #endregion
+
+        #region ByteRange
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRangeCollection_GetSize(PdfByteRangeCollectionSafeHandle handle, out UIntPtr data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRangeCollection_GetValue(PdfByteRangeCollectionSafeHandle handle, UIntPtr at, out PdfByteRangeSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRangeCollection_Release(IntPtr handle);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRange_GetOffset(PdfByteRangeSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRange_GetLength(PdfByteRangeSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ByteRange_Release(IntPtr handle);
 
         #endregion
 

--- a/src/vanillapdf.net/Interop/NativeMethods.Semantics.LibraryImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Semantics.LibraryImport.cs
@@ -266,7 +266,56 @@ namespace vanillapdf.net.Interop
         #region DigitalSignature
 
         [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetContactInfo(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetReason(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetLocation(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetSigningTime(PdfDigitalSignatureSafeHandle handle, out PdfDateSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetName(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetRevision(PdfDigitalSignatureSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetCertificate(PdfDigitalSignatureSafeHandle handle, out PdfStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetContents(PdfDigitalSignatureSafeHandle handle, out PdfHexadecimalStringObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 DigitalSignature_GetByteRange(PdfDigitalSignatureSafeHandle handle, out PdfByteRangeCollectionSafeHandle data);
+
+        [LibraryImport(LibraryName)]
         public static partial UInt32 DigitalSignature_Release(IntPtr handle);
+
+        #endregion
+
+        #region ByteRange
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRangeCollection_GetSize(PdfByteRangeCollectionSafeHandle handle, out UIntPtr data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRangeCollection_GetValue(PdfByteRangeCollectionSafeHandle handle, UIntPtr at, out PdfByteRangeSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRangeCollection_Release(IntPtr handle);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRange_GetOffset(PdfByteRangeSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRange_GetLength(PdfByteRangeSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ByteRange_Release(IntPtr handle);
 
         #endregion
 

--- a/src/vanillapdf.net/PdfSemantics/PdfByteRange.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfByteRange.cs
@@ -1,0 +1,56 @@
+using System;
+using vanillapdf.net.Interop;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+using vanillapdf.net.Utils;
+
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// Represents a single contiguous byte range (offset and length) within a PDF file,
+    /// used for digital signature digest calculation.
+    /// </summary>
+    public class PdfByteRange : IDisposable
+    {
+        internal PdfByteRangeSafeHandle Handle { get; }
+
+        internal PdfByteRange(PdfByteRangeSafeHandle handle)
+        {
+            Handle = handle;
+        }
+
+        /// <summary>
+        /// Get the byte offset where this range starts.
+        /// </summary>
+        /// <returns>The <see cref="PdfIntegerObject"/> holding the offset.</returns>
+        public PdfIntegerObject GetOffset()
+        {
+            UInt32 result = NativeMethods.ByteRange_GetOffset(Handle, out PdfIntegerObjectSafeHandle data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfIntegerObject(data);
+        }
+
+        /// <summary>
+        /// Get the length of this range in bytes.
+        /// </summary>
+        /// <returns>The <see cref="PdfIntegerObject"/> holding the length.</returns>
+        public PdfIntegerObject GetLength()
+        {
+            UInt32 result = NativeMethods.ByteRange_GetLength(Handle, out PdfIntegerObjectSafeHandle data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfIntegerObject(data);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Handle?.Dispose();
+        }
+    }
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfByteRange.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfByteRange.cs
@@ -20,32 +20,36 @@ namespace vanillapdf.net.PdfSemantics
         }
 
         /// <summary>
-        /// Get the byte offset where this range starts.
+        /// The byte offset where this range starts.
         /// </summary>
-        /// <returns>The <see cref="PdfIntegerObject"/> holding the offset.</returns>
-        public PdfIntegerObject GetOffset()
+        public PdfIntegerObject Offset => GetOffset();
+
+        /// <summary>
+        /// The length of this range in bytes.
+        /// </summary>
+        public PdfIntegerObject Length => GetLength();
+
+        #region Private Methods
+
+        private PdfIntegerObject GetOffset()
         {
             UInt32 result = NativeMethods.ByteRange_GetOffset(Handle, out PdfIntegerObjectSafeHandle data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
-
             return new PdfIntegerObject(data);
         }
 
-        /// <summary>
-        /// Get the length of this range in bytes.
-        /// </summary>
-        /// <returns>The <see cref="PdfIntegerObject"/> holding the length.</returns>
-        public PdfIntegerObject GetLength()
+        private PdfIntegerObject GetLength()
         {
             UInt32 result = NativeMethods.ByteRange_GetLength(Handle, out PdfIntegerObjectSafeHandle data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
-
             return new PdfIntegerObject(data);
         }
+
+        #endregion
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/vanillapdf.net/PdfSemantics/PdfByteRangeCollection.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfByteRangeCollection.cs
@@ -1,0 +1,56 @@
+using System;
+using vanillapdf.net.Interop;
+using vanillapdf.net.PdfUtils;
+using vanillapdf.net.Utils;
+
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// An ordered collection of byte ranges describing the exact portions
+    /// of a PDF file covered by a digital signature digest.
+    /// </summary>
+    public class PdfByteRangeCollection : IDisposable
+    {
+        internal PdfByteRangeCollectionSafeHandle Handle { get; }
+
+        internal PdfByteRangeCollection(PdfByteRangeCollectionSafeHandle handle)
+        {
+            Handle = handle;
+        }
+
+        /// <summary>
+        /// Get the number of byte ranges in the collection.
+        /// </summary>
+        /// <returns>The byte range count.</returns>
+        public UInt64 GetSize()
+        {
+            UInt32 result = NativeMethods.ByteRangeCollection_GetSize(Handle, out UIntPtr data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data.ToUInt64();
+        }
+
+        /// <summary>
+        /// Get the byte range at the specified index.
+        /// </summary>
+        /// <param name="index">Zero-based index of the byte range to retrieve.</param>
+        /// <returns>The <see cref="PdfByteRange"/> at <paramref name="index"/>.</returns>
+        public PdfByteRange GetValueAt(UInt64 index)
+        {
+            UInt32 result = NativeMethods.ByteRangeCollection_GetValue(Handle, new UIntPtr(index), out PdfByteRangeSafeHandle data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfByteRange(data);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Handle?.Dispose();
+        }
+    }
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfDigitalSignature.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDigitalSignature.cs
@@ -1,5 +1,6 @@
 using System;
 using vanillapdf.net.Interop;
+using vanillapdf.net.PdfSyntax;
 using vanillapdf.net.PdfUtils;
 using vanillapdf.net.Utils;
 
@@ -15,6 +16,173 @@ namespace vanillapdf.net.PdfSemantics
         internal PdfDigitalSignature(PdfDigitalSignatureSafeHandle handle)
         {
             Handle = handle;
+        }
+
+        /// <summary>
+        /// Get the name of the person or authority signing the document (/Name entry).
+        /// </summary>
+        /// <returns>The <see cref="PdfStringObject"/> holding the name, or null if not present.</returns>
+        public PdfStringObject GetName()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetName(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the reason for the signing (/Reason entry), such as "I agree...".
+        /// </summary>
+        /// <returns>The <see cref="PdfStringObject"/> holding the reason, or null if not present.</returns>
+        public PdfStringObject GetReason()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetReason(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the CPU host name or physical location of the signing (/Location entry).
+        /// </summary>
+        /// <returns>The <see cref="PdfStringObject"/> holding the location, or null if not present.</returns>
+        public PdfStringObject GetLocation()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetLocation(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the information provided by the signer to enable a recipient
+        /// to contact the signer (/ContactInfo entry).
+        /// </summary>
+        /// <returns>The <see cref="PdfStringObject"/> holding the contact information, or null if not present.</returns>
+        public PdfStringObject GetContactInfo()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetContactInfo(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the time of signing (/M entry).
+        /// Depending on the signature handler, this may be a normal unverified computer time
+        /// or a time generated in a verifiable way from a secure time server.
+        /// </summary>
+        /// <returns>The <see cref="PdfDate"/> holding the signing time, or null if not present.</returns>
+        public PdfDate GetSigningTime()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetSigningTime(Handle, out PdfDateSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfDate(data);
+        }
+
+        /// <summary>
+        /// Get the version of the signature handler that was used to create the signature (/R entry).
+        /// </summary>
+        /// <returns>The <see cref="PdfIntegerObject"/> holding the revision, or null if not present.</returns>
+        public PdfIntegerObject GetRevision()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetRevision(Handle, out PdfIntegerObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfIntegerObject(data);
+        }
+
+        /// <summary>
+        /// Get the X.509 certificate chain used when signing (/Cert entry).
+        /// The signing certificate appears first.
+        /// </summary>
+        /// <returns>The <see cref="PdfStringObject"/> holding the certificate data, or null if not present.</returns>
+        public PdfStringObject GetCertificate()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetCertificate(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the signature value (/Contents entry).
+        /// For public-key signatures this is a DER-encoded PKCS#1 or PKCS#7 binary data object.
+        /// </summary>
+        /// <returns>The <see cref="PdfHexadecimalStringObject"/> holding the signature value, or null if not present.</returns>
+        public PdfHexadecimalStringObject GetContents()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetContents(Handle, out PdfHexadecimalStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfHexadecimalStringObject(data);
+        }
+
+        /// <summary>
+        /// Get the exact byte ranges used for the digest calculation (/ByteRange entry).
+        /// </summary>
+        /// <returns>The <see cref="PdfByteRangeCollection"/>, or null if not present.</returns>
+        public PdfByteRangeCollection GetByteRange()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetByteRange(Handle, out PdfByteRangeCollectionSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfByteRangeCollection(data);
         }
 
         /// <summary>

--- a/src/vanillapdf.net/PdfSemantics/PdfDigitalSignature.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDigitalSignature.cs
@@ -19,171 +19,59 @@ namespace vanillapdf.net.PdfSemantics
         }
 
         /// <summary>
-        /// Get the name of the person or authority signing the document (/Name entry).
+        /// The name of the person or authority signing the document (/Name entry),
+        /// or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfStringObject"/> holding the name, or null if not present.</returns>
-        public PdfStringObject GetName()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetName(Handle, out PdfStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfStringObject(data);
-        }
+        public PdfStringObject Name => GetName();
 
         /// <summary>
-        /// Get the reason for the signing (/Reason entry), such as "I agree...".
+        /// The reason for the signing (/Reason entry), such as "I agree...",
+        /// or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfStringObject"/> holding the reason, or null if not present.</returns>
-        public PdfStringObject GetReason()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetReason(Handle, out PdfStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfStringObject(data);
-        }
+        public PdfStringObject Reason => GetReason();
 
         /// <summary>
-        /// Get the CPU host name or physical location of the signing (/Location entry).
+        /// The CPU host name or physical location of the signing (/Location entry),
+        /// or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfStringObject"/> holding the location, or null if not present.</returns>
-        public PdfStringObject GetLocation()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetLocation(Handle, out PdfStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfStringObject(data);
-        }
+        public PdfStringObject Location => GetLocation();
 
         /// <summary>
-        /// Get the information provided by the signer to enable a recipient
-        /// to contact the signer (/ContactInfo entry).
+        /// The information provided by the signer to enable a recipient
+        /// to contact the signer (/ContactInfo entry), or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfStringObject"/> holding the contact information, or null if not present.</returns>
-        public PdfStringObject GetContactInfo()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetContactInfo(Handle, out PdfStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfStringObject(data);
-        }
+        public PdfStringObject ContactInfo => GetContactInfo();
 
         /// <summary>
-        /// Get the time of signing (/M entry).
+        /// The time of signing (/M entry), or null if not present.
         /// Depending on the signature handler, this may be a normal unverified computer time
         /// or a time generated in a verifiable way from a secure time server.
         /// </summary>
-        /// <returns>The <see cref="PdfDate"/> holding the signing time, or null if not present.</returns>
-        public PdfDate GetSigningTime()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetSigningTime(Handle, out PdfDateSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfDate(data);
-        }
+        public PdfDate SigningTime => GetSigningTime();
 
         /// <summary>
-        /// Get the version of the signature handler that was used to create the signature (/R entry).
+        /// The version of the signature handler that was used to create the signature (/R entry),
+        /// or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfIntegerObject"/> holding the revision, or null if not present.</returns>
-        public PdfIntegerObject GetRevision()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetRevision(Handle, out PdfIntegerObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfIntegerObject(data);
-        }
+        public PdfIntegerObject Revision => GetRevision();
 
         /// <summary>
-        /// Get the X.509 certificate chain used when signing (/Cert entry).
-        /// The signing certificate appears first.
+        /// The X.509 certificate chain used when signing (/Cert entry),
+        /// or null if not present. The signing certificate appears first.
         /// </summary>
-        /// <returns>The <see cref="PdfStringObject"/> holding the certificate data, or null if not present.</returns>
-        public PdfStringObject GetCertificate()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetCertificate(Handle, out PdfStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfStringObject(data);
-        }
+        public PdfStringObject Certificate => GetCertificate();
 
         /// <summary>
-        /// Get the signature value (/Contents entry).
+        /// The signature value (/Contents entry), or null if not present.
         /// For public-key signatures this is a DER-encoded PKCS#1 or PKCS#7 binary data object.
         /// </summary>
-        /// <returns>The <see cref="PdfHexadecimalStringObject"/> holding the signature value, or null if not present.</returns>
-        public PdfHexadecimalStringObject GetContents()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetContents(Handle, out PdfHexadecimalStringObjectSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfHexadecimalStringObject(data);
-        }
+        public PdfHexadecimalStringObject Contents => GetContents();
 
         /// <summary>
-        /// Get the exact byte ranges used for the digest calculation (/ByteRange entry).
+        /// The exact byte ranges used for the digest calculation (/ByteRange entry),
+        /// or null if not present.
         /// </summary>
-        /// <returns>The <see cref="PdfByteRangeCollection"/>, or null if not present.</returns>
-        public PdfByteRangeCollection GetByteRange()
-        {
-            UInt32 result = NativeMethods.DigitalSignature_GetByteRange(Handle, out PdfByteRangeCollectionSafeHandle data);
-            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
-                return null;
-            }
-
-            if (result != PdfReturnValues.ERROR_SUCCESS) {
-                throw PdfErrors.GetLastErrorException();
-            }
-
-            return new PdfByteRangeCollection(data);
-        }
+        public PdfByteRangeCollection ByteRange => GetByteRange();
 
         /// <summary>
         /// Verify this digital signature against the given document and trust store.
@@ -212,6 +100,118 @@ namespace vanillapdf.net.PdfSemantics
 
             return new SignatureVerificationResult(resultHandle);
         }
+
+        #region Private Methods
+
+        private PdfStringObject GetName()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetName(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetReason()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetReason(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetLocation()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetLocation(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfStringObject GetContactInfo()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetContactInfo(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfDate GetSigningTime()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetSigningTime(Handle, out PdfDateSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfDate(data);
+        }
+
+        private PdfIntegerObject GetRevision()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetRevision(Handle, out PdfIntegerObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfIntegerObject(data);
+        }
+
+        private PdfStringObject GetCertificate()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetCertificate(Handle, out PdfStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfStringObject(data);
+        }
+
+        private PdfHexadecimalStringObject GetContents()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetContents(Handle, out PdfHexadecimalStringObjectSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfHexadecimalStringObject(data);
+        }
+
+        private PdfByteRangeCollection GetByteRange()
+        {
+            UInt32 result = NativeMethods.DigitalSignature_GetByteRange(Handle, out PdfByteRangeCollectionSafeHandle data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfByteRangeCollection(data);
+        }
+
+        #endregion
 
         /// <inheritdoc/>
         public void Dispose()

--- a/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
+++ b/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
@@ -797,4 +797,14 @@ namespace vanillapdf.net.Utils
     {
         protected override bool ReleaseHandle() => NativeMethods.DigitalSignature_Release(handle) == PdfReturnValues.ERROR_SUCCESS;
     }
+
+    internal sealed class PdfByteRangeSafeHandle : PdfSafeHandle
+    {
+        protected override bool ReleaseHandle() => NativeMethods.ByteRange_Release(handle) == PdfReturnValues.ERROR_SUCCESS;
+    }
+
+    internal sealed class PdfByteRangeCollectionSafeHandle : PdfSafeHandle
+    {
+        protected override bool ReleaseHandle() => NativeMethods.ByteRangeCollection_Release(handle) == PdfReturnValues.ERROR_SUCCESS;
+    }
 }


### PR DESCRIPTION
## Summary
- Wraps the digital signature dictionary accessors introduced in vanillapdf 2.3.0-beta.1: `GetName`, `GetReason`, `GetLocation`, `GetContactInfo`, `GetSigningTime`, `GetRevision`, `GetCertificate`, `GetContents`, `GetByteRange`
- Adds `PdfByteRange` and `PdfByteRangeCollection` wrappers with read access to digest byte ranges
- Getters return null on missing dictionary entries, following the `PdfDocumentInfo` pattern
- New tests sign to in-memory streams (`PdfInputOutputStream.CreateFromMemory`) instead of temporary files

## Notes
- `SignatureVerificationSettings_Get/SetCheckRevocationFlag` is declared in the beta.1 headers but **not exported from the binaries** (`EntryPointNotFoundException` at runtime), so the CheckRevocation setting is intentionally not wrapped yet. Worth reporting upstream before 2.3.0 final.

## Test plan
- [x] `dotnet build` Release: 0 warnings, 0 errors
- [x] Full suite: 231 tests pass on net9.0 and net10.0, including new metadata roundtrip, missing-metadata null checks, and byte-range structure tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)