### PR TITLE
Add PdfTextStringEncoding utility for PDF text string encodings

### DIFF
--- a/src/vanillapdf.net.nunit/PdfUtils/TextStringEncodingTest.cs
+++ b/src/vanillapdf.net.nunit/PdfUtils/TextStringEncodingTest.cs
@@ -1,0 +1,70 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System;
+using System.Text;
+using vanillapdf.net.PdfUtils;
+
+namespace vanillapdf.net.nunit.PdfUtils
+{
+    [TestFixture]
+    public class TextStringEncodingTest
+    {
+        [Test]
+        public void TestEncodingTypeEnumValues()
+        {
+            var values = Enum.GetValues(typeof(PdfTextStringEncodingType));
+            ClassicAssert.AreEqual(4, values.Length, "PdfTextStringEncodingType should have 4 values");
+
+            ClassicAssert.IsTrue(Enum.IsDefined(typeof(PdfTextStringEncodingType), PdfTextStringEncodingType.Undefined));
+            ClassicAssert.IsTrue(Enum.IsDefined(typeof(PdfTextStringEncodingType), PdfTextStringEncodingType.PDFDocEncoding));
+            ClassicAssert.IsTrue(Enum.IsDefined(typeof(PdfTextStringEncodingType), PdfTextStringEncodingType.UTF16BE));
+            ClassicAssert.IsTrue(Enum.IsDefined(typeof(PdfTextStringEncodingType), PdfTextStringEncodingType.UTF8));
+        }
+
+        [Test]
+        public void TestDetectUtf8()
+        {
+            byte[] data = { 0xEF, 0xBB, 0xBF, 0x48, 0x65, 0x6C, 0x6C, 0x6F };
+            ClassicAssert.AreEqual(PdfTextStringEncodingType.UTF8, PdfTextStringEncoding.Detect(data));
+        }
+
+        [Test]
+        public void TestDetectUtf16BigEndian()
+        {
+            byte[] data = { 0xFE, 0xFF, 0x00, 0x48, 0x00, 0x69 };
+            ClassicAssert.AreEqual(PdfTextStringEncodingType.UTF16BE, PdfTextStringEncoding.Detect(data));
+        }
+
+        [Test]
+        public void TestDetectPdfDocEncoding()
+        {
+            byte[] data = Encoding.ASCII.GetBytes("Hello world");
+            ClassicAssert.AreEqual(PdfTextStringEncodingType.PDFDocEncoding, PdfTextStringEncoding.Detect(data));
+        }
+
+        [Test]
+        public void TestDetectNullThrows()
+        {
+            Assert.Throws<ArgumentNullException>(DetectNull);
+        }
+
+        [Test]
+        public void TestPdfDocEncodingAsciiByteMapsToItself()
+        {
+            ClassicAssert.AreEqual(0x41u, PdfTextStringEncoding.PDFDocEncodingByteToUnicode(0x41));
+            ClassicAssert.AreEqual(0x7Au, PdfTextStringEncoding.PDFDocEncodingByteToUnicode(0x7A));
+        }
+
+        [Test]
+        public void TestPdfDocEncodingEuroSign()
+        {
+            // PDF spec Table D.2: PDFDocEncoding 0xA0 is the euro sign
+            ClassicAssert.AreEqual(0x20ACu, PdfTextStringEncoding.PDFDocEncodingByteToUnicode(0xA0));
+        }
+
+        private static void DetectNull()
+        {
+            PdfTextStringEncoding.Detect(null);
+        }
+    }
+}

--- a/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
@@ -356,6 +356,16 @@ namespace vanillapdf.net.Interop
             out SignatureVerificationResultSafeHandle result);
 
         #endregion
+
+        #region TextStringEncoding
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 TextStringEncoding_Detect(byte[] data, UIntPtr size, out Int32 result);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 TextStringEncoding_PDFDocEncodingByteToUnicode(byte value, out UInt32 codepoint);
+
+        #endregion
     }
 }
 

--- a/src/vanillapdf.net/Interop/NativeMethods.Core.LibraryImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Core.LibraryImport.cs
@@ -342,6 +342,16 @@ namespace vanillapdf.net.Interop
             out SignatureVerificationResultSafeHandle result);
 
         #endregion
+
+        #region TextStringEncoding
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 TextStringEncoding_Detect(byte[] data, UIntPtr size, out Int32 result);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 TextStringEncoding_PDFDocEncodingByteToUnicode(byte value, out UInt32 codepoint);
+
+        #endregion
     }
 }
 

--- a/src/vanillapdf.net/PdfUtils/PdfTextStringEncoding.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfTextStringEncoding.cs
@@ -1,0 +1,45 @@
+using System;
+using vanillapdf.net.Interop;
+using vanillapdf.net.Utils;
+
+namespace vanillapdf.net.PdfUtils
+{
+    /// <summary>
+    /// Utilities for working with PDF text string encodings (PDF spec 7.9.2.2).
+    /// </summary>
+    public static class PdfTextStringEncoding
+    {
+        /// <summary>
+        /// Detect the encoding of raw text string data by inspecting its byte order mark.
+        /// Data without a byte order mark is reported as <see cref="PdfTextStringEncodingType.PDFDocEncoding"/>.
+        /// </summary>
+        /// <param name="data">Raw bytes of the text string to inspect.</param>
+        /// <returns>The detected <see cref="PdfTextStringEncodingType"/>.</returns>
+        public static PdfTextStringEncodingType Detect(byte[] data)
+        {
+            if (data == null) throw new ArgumentNullException(nameof(data));
+
+            UInt32 result = NativeMethods.TextStringEncoding_Detect(data, new UIntPtr((uint)data.Length), out Int32 value);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return EnumUtil<PdfTextStringEncodingType>.CheckedCast(value);
+        }
+
+        /// <summary>
+        /// Convert a single PDFDocEncoding byte (PDF spec Table D.2) to its Unicode code point.
+        /// </summary>
+        /// <param name="value">The PDFDocEncoding byte to convert.</param>
+        /// <returns>The Unicode code point the byte maps to.</returns>
+        public static UInt32 PDFDocEncodingByteToUnicode(byte value)
+        {
+            UInt32 result = NativeMethods.TextStringEncoding_PDFDocEncodingByteToUnicode(value, out UInt32 codepoint);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return codepoint;
+        }
+    }
+}

--- a/src/vanillapdf.net/PdfUtils/PdfTextStringEncodingType.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfTextStringEncodingType.cs
@@ -1,0 +1,29 @@
+namespace vanillapdf.net.PdfUtils
+{
+    /// <summary>
+    /// Encoding types for PDF text strings (PDF spec 7.9.2.2).
+    /// </summary>
+    public enum PdfTextStringEncodingType
+    {
+        /// <summary>Undefined, uninitialized default.</summary>
+        Undefined = 0,
+
+        /// <summary>
+        /// Single-byte encoding defined in PDF spec Table D.2.
+        /// No byte order mark is present.
+        /// </summary>
+        PDFDocEncoding = 1,
+
+        /// <summary>
+        /// UTF-16 big-endian encoding.
+        /// Indicated by byte order mark 0xFEFF at the start of the string.
+        /// </summary>
+        UTF16BE = 2,
+
+        /// <summary>
+        /// UTF-8 encoding (PDF 2.0).
+        /// Indicated by byte order mark 0xEFBBBF at the start of the string.
+        /// </summary>
+        UTF8 = 3
+    }
+}


### PR DESCRIPTION
## Summary
- Wraps the `TextStringEncoding` API introduced in vanillapdf 2.3.0-beta.1 (`utils/c_text_string_encoding.h`)
- `PdfTextStringEncoding.Detect(byte[])` — BOM-based encoding detection returning the new `PdfTextStringEncodingType` enum (Undefined / PDFDocEncoding / UTF16BE / UTF8)
- `PdfTextStringEncoding.PDFDocEncodingByteToUnicode(byte)` — single-byte PDFDocEncoding to Unicode code point conversion per PDF spec Table D.2

## Test plan
- [x] `dotnet build` Release: 0 warnings, 0 errors
- [x] Full suite: 235 tests pass on net9.0 and net10.0, including BOM detection for all three encodings and the Table D.2 euro-sign mapping (0xA0 → U+20AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)