### PR TITLE
Fix marshaling of 1-byte native boolean_type on .NET Framework path

### DIFF
--- a/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
@@ -38,10 +38,10 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 LicenseInfo_SetLicenseBuffer(PdfBufferSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 LicenseInfo_IsValid(out bool data);
+        public static extern UInt32 LicenseInfo_IsValid([MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 LicenseInfo_IsTemporary(out bool data);
+        public static extern UInt32 LicenseInfo_IsTemporary([MarshalAs(UnmanagedType.I1)] out bool data);
 
         #endregion
 
@@ -92,7 +92,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 Buffer_ToInputStream(PdfBufferSafeHandle handle, out PdfInputStreamSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 Buffer_Equals(PdfBufferSafeHandle handle, PdfBufferSafeHandle other, out bool data);
+        public static extern UInt32 Buffer_Equals(PdfBufferSafeHandle handle, PdfBufferSafeHandle other, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 Buffer_Hash(PdfBufferSafeHandle handle, out UIntPtr data);
@@ -292,22 +292,22 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 SignatureVerificationSettings_Create(out SignatureVerificationSettingsSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_GetSkipCertificateValidation(SignatureVerificationSettingsSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationSettings_GetSkipCertificateValidation(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_SetSkipCertificateValidation(SignatureVerificationSettingsSafeHandle handle, bool value);
+        public static extern UInt32 SignatureVerificationSettings_SetSkipCertificateValidation(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_GetCheckSigningTimeFlag(SignatureVerificationSettingsSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationSettings_GetCheckSigningTimeFlag(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_SetCheckSigningTimeFlag(SignatureVerificationSettingsSafeHandle handle, bool value);
+        public static extern UInt32 SignatureVerificationSettings_SetCheckSigningTimeFlag(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_GetAllowWeakAlgorithmsFlag(SignatureVerificationSettingsSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationSettings_GetAllowWeakAlgorithmsFlag(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationSettings_SetAllowWeakAlgorithmsFlag(SignatureVerificationSettingsSafeHandle handle, bool value);
+        public static extern UInt32 SignatureVerificationSettings_SetAllowWeakAlgorithmsFlag(SignatureVerificationSettingsSafeHandle handle, [MarshalAs(UnmanagedType.I1)] bool value);
 
         #endregion
 
@@ -323,13 +323,13 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 SignatureVerificationResult_GetMessage(SignatureVerificationResultSafeHandle handle, out PdfBufferSafeHandle buffer);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationResult_IsSignatureValid(SignatureVerificationResultSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationResult_IsSignatureValid(SignatureVerificationResultSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationResult_IsDocumentIntact(SignatureVerificationResultSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationResult_IsDocumentIntact(SignatureVerificationResultSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 SignatureVerificationResult_IsCertificateTrusted(SignatureVerificationResultSafeHandle handle, out bool value);
+        public static extern UInt32 SignatureVerificationResult_IsCertificateTrusted(SignatureVerificationResultSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool value);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 SignatureVerificationResult_GetSignerCertificate(SignatureVerificationResultSafeHandle handle, out PdfBufferSafeHandle buffer);

--- a/src/vanillapdf.net/Interop/NativeMethods.Syntax.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Syntax.DllImport.cs
@@ -49,7 +49,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 File_GetFilename(PdfFileSafeHandle handle, out PdfBufferSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 File_IsEncrypted(PdfFileSafeHandle handle, out bool data);
+        public static extern UInt32 File_IsEncrypted(PdfFileSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 File_SetEncryptionPassword(
@@ -203,22 +203,22 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 DictionaryObject_Find(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, out PdfObjectSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 DictionaryObject_TryFind(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, out bool contains, out PdfObjectSafeHandle data);
+        public static extern UInt32 DictionaryObject_TryFind(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, [MarshalAs(UnmanagedType.I1)] out bool contains, out PdfObjectSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 DictionaryObject_Contains(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, out bool data);
+        public static extern UInt32 DictionaryObject_Contains(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 DictionaryObject_GetIterator(PdfDictionaryObjectSafeHandle handle, out PdfDictionaryObjectIteratorSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 DictionaryObject_Remove(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, out bool data);
+        public static extern UInt32 DictionaryObject_Remove(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 DictionaryObject_Clear(PdfDictionaryObjectSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 DictionaryObject_Insert(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, PdfObjectSafeHandle data, bool overwrite);
+        public static extern UInt32 DictionaryObject_Insert(PdfDictionaryObjectSafeHandle handle, PdfNameObjectSafeHandle key, PdfObjectSafeHandle data, [MarshalAs(UnmanagedType.I1)] bool overwrite);
 
         #endregion
 
@@ -237,7 +237,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 DictionaryObjectIterator_Next(PdfDictionaryObjectIteratorSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 DictionaryObjectIterator_IsValid(PdfDictionaryObjectIteratorSafeHandle handle, out bool data);
+        public static extern UInt32 DictionaryObjectIterator_IsValid(PdfDictionaryObjectIteratorSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         #endregion
 
@@ -306,10 +306,10 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 BooleanObject_Create(out PdfBooleanObjectSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 BooleanObject_GetValue(PdfBooleanObjectSafeHandle handle, out bool data);
+        public static extern UInt32 BooleanObject_GetValue(PdfBooleanObjectSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 BooleanObject_SetValue(PdfBooleanObjectSafeHandle handle, bool data);
+        public static extern UInt32 BooleanObject_SetValue(PdfBooleanObjectSafeHandle handle, [MarshalAs(UnmanagedType.I1)] bool data);
 
         #endregion
 
@@ -356,7 +356,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 NameObject_SetValue(PdfNameObjectSafeHandle handle, PdfBufferSafeHandle data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 NameObject_Equals(PdfNameObjectSafeHandle handle, PdfNameObjectSafeHandle other, out bool data);
+        public static extern UInt32 NameObject_Equals(PdfNameObjectSafeHandle handle, PdfNameObjectSafeHandle other, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 NameObject_Hash(PdfNameObjectSafeHandle handle, out UIntPtr data);
@@ -565,7 +565,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 ObjectAttributeList_Remove(PdfObjectAttributeListSafeHandle handle, PdfSyntax.PdfObjectAttributeType key);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 ObjectAttributeList_Contains(PdfObjectAttributeListSafeHandle handle, PdfSyntax.PdfObjectAttributeType key, out bool result);
+        public static extern UInt32 ObjectAttributeList_Contains(PdfObjectAttributeListSafeHandle handle, PdfSyntax.PdfObjectAttributeType key, [MarshalAs(UnmanagedType.I1)] out bool result);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 ObjectAttributeList_Get(PdfObjectAttributeListSafeHandle handle, PdfSyntax.PdfObjectAttributeType key, out PdfBaseObjectAttributeSafeHandle result);

--- a/src/vanillapdf.net/Interop/NativeMethods.Xref.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Xref.DllImport.cs
@@ -36,7 +36,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 XrefIterator_Next(PdfXrefIteratorSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 XrefIterator_IsValid(PdfXrefIteratorSafeHandle handle, out bool data);
+        public static extern UInt32 XrefIterator_IsValid(PdfXrefIteratorSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         #endregion
 
@@ -65,7 +65,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 XrefChainIterator_Next(PdfXrefChainIteratorSafeHandle handle);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 XrefChainIterator_IsValid(PdfXrefChainIteratorSafeHandle handle, out bool data);
+        public static extern UInt32 XrefChainIterator_IsValid(PdfXrefChainIteratorSafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         #endregion
 
@@ -84,7 +84,7 @@ namespace vanillapdf.net.Interop
         public static extern UInt32 XrefEntry_GetGenerationNumber(PdfXrefEntrySafeHandle handle, out UInt16 data);
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
-        public static extern UInt32 XrefEntry_InUse(PdfXrefEntrySafeHandle handle, out bool data);
+        public static extern UInt32 XrefEntry_InUse(PdfXrefEntrySafeHandle handle, [MarshalAs(UnmanagedType.I1)] out bool data);
 
         #endregion
 


### PR DESCRIPTION
## Summary
Native `boolean_type` is `int8_t` (1 byte), but the netstandard2.0 `DllImport` declarations used a bare `bool`, which marshals as a 4-byte Win32 `BOOL`. For `out` parameters the marshaler reads 3 uninitialized bytes past the byte native code writes, which can turn a native `false` (0) into a managed `true`.

Adds `[MarshalAs(UnmanagedType.I1)]` to every `bool` parameter across the `Core`, `Syntax`, and `Xref` DllImport files (25 parameters), matching the native `int8_t` and the `[MarshalAs(UnmanagedType.I1)]` already present in the `Semantics` and `Contents` DllImport files. The `LibraryImport` path (net7.0+) already pins these to one byte via `[MarshalAs(UnmanagedType.U1)]`, so modern .NET was never affected.

Attribute-only change — no logic or signature-shape changes.

## Test plan
- [x] `dotnet build` Release: 0 warnings, 0 errors (netstandard2.0 target compiles)
- [x] Full suite: 228 tests pass on net9.0 and net10.0
- [ ] CI `test_net_framework.sh` exercises the affected DllImport path

🤖 Generated with [Claude Code](https://claude.com/claude-code)