### PR TITLE
ci: Adopt NuGet trusted publishing (OIDC) for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,17 +97,28 @@ jobs:
     runs-on: ubuntu-latest
     needs: production-gate
     environment: production
+    permissions:
+      id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
     steps:
       - name: Download NuGet packages
         uses: actions/download-artifact@v8
         with:
           path: ./nupkgs
 
+      # Exchange the OIDC token for a short-lived nuget.org API key (valid 1 hour).
+      # Requires a Trusted Publishing policy on nuget.org bound to this repo,
+      # workflow file (release.yml) and the production environment.
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet.org
         run: |
           dotnet nuget push nupkgs/**/*.nupkg \
             --source "${{ vars.NUGET_SOURCE }}" \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
 
   github-release:


### PR DESCRIPTION
## Summary

Migrate the `publish-nuget` job in the release workflow from a long-lived `NUGET_API_KEY` to **NuGet trusted publishing** (OIDC), in line with nuget.org moving away from API keys. Mirrors vanillapdf/vanillapdf#399.

The job now:
- Requests a GitHub OIDC token (`id-token: write`, scoped to the job)
- Exchanges it for a short-lived nuget.org API key via `NuGet/login` (pinned to commit SHA, valid 1 hour)
- Pushes with that temporary key instead of the stored secret

Staging pushes to GitHub Packages (`GITHUB_TOKEN`) are unaffected.

## Required setup (account-side, before/at merge)

- [x] Trusted Publishing policy on nuget.org bound to: Repository Owner `vanillapdf`, Repository `vanillapdf-net`, Workflow File `release.yml`, Environment `production`. Policy owner must be `Vanilla.PDF`.
- [x] `NUGET_USER` set as a `production` environment secret (`Vanilla.PDF`)
- [x] After a release is confirmed working via OIDC: delete the `NUGET_API_KEY` production environment secret and revoke the key on nuget.org

## Backport

Backported to `release/2.2` separately. The old key should not be removed until **both** branches publish successfully via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)