### PR TITLE
ci: Adopt NuGet trusted publishing (OIDC) for release (backport to release/2.2)

### DIFF
--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
+    permissions:
+      id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
 
     needs: publish-nuget-github
     steps:
@@ -71,9 +73,18 @@ jobs:
         with:
           path: ./nupkgs
 
+      # Exchange the OIDC token for a short-lived nuget.org API key (valid 1 hour).
+      # Requires a Trusted Publishing policy on nuget.org bound to this repo,
+      # workflow file (publish-nuget-packages.yml) and the production environment.
+      - name: NuGet login (OIDC -> temporary API key)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push to NuGet.org
         run: |
           dotnet nuget push nupkgs/**/*.nupkg \
             --source "${{ vars.NUGET_SOURCE }}" \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate


### PR DESCRIPTION
## Summary

Backport of #108 to `release/2.2`. On this branch the NuGet.org publish lives in `publish-nuget-packages.yml` (job `publish-nuget-official`), so the change is applied there.

Migrate from a long-lived `NUGET_API_KEY` to **NuGet trusted publishing** (OIDC):
- Requests a GitHub OIDC token (`id-token: write`, scoped to the job)
- Exchanges it for a short-lived nuget.org API key via `NuGet/login` (pinned to commit SHA, valid 1 hour)
- Pushes with that temporary key instead of the stored secret

Staging pushes to GitHub Packages (`GITHUB_TOKEN`) are unaffected.

## Required setup (account-side)

- [x] Trusted Publishing policy on nuget.org bound to: Repository Owner `vanillapdf`, Repository `vanillapdf-net`, **Workflow File `publish-nuget-packages.yml`**, Environment `production`. Policy owner must be `Vanilla.PDF`. (Note: this is a *separate* policy from the `main`/`release.yml` one, since the workflow file name differs.)
- [x] `NUGET_USER` set as a `production` environment secret (`Vanilla.PDF`)
- [x] Do not delete `NUGET_API_KEY` / revoke the key until **both** `main` (#108) and `release/2.2` have published successfully via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)