### PR TITLE
Add PdfLibraryInfo for native library version and build metadata

### DIFF
--- a/src/vanillapdf.net.nunit/PdfUtils/PdfLibraryInfoTest.cs
+++ b/src/vanillapdf.net.nunit/PdfUtils/PdfLibraryInfoTest.cs
@@ -1,0 +1,38 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using vanillapdf.net.PdfUtils;
+
+namespace vanillapdf.net.nunit.PdfUtils
+{
+    [TestFixture]
+    public class PdfLibraryInfoTest
+    {
+        [Test]
+        public void TestVersionIsPopulated()
+        {
+            // The native library currently reports a 2.x version
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.VersionMajor, 2);
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.VersionMinor, 0);
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.VersionPatch, 0);
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.VersionBuild, 0);
+        }
+
+        [Test]
+        public void TestAuthorIsNotEmpty()
+        {
+            ClassicAssert.IsFalse(string.IsNullOrEmpty(PdfLibraryInfo.Author));
+        }
+
+        [Test]
+        public void TestBuildDateIsPlausible()
+        {
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.BuildDay, 1);
+            ClassicAssert.LessOrEqual(PdfLibraryInfo.BuildDay, 31);
+
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.BuildMonth, 1);
+            ClassicAssert.LessOrEqual(PdfLibraryInfo.BuildMonth, 12);
+
+            ClassicAssert.GreaterOrEqual(PdfLibraryInfo.BuildYear, 2020);
+        }
+    }
+}

--- a/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Core.DllImport.cs
@@ -45,6 +45,34 @@ namespace vanillapdf.net.Interop
 
         #endregion
 
+        #region LibraryInfo
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetVersionMajor(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetVersionMinor(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetVersionPatch(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetVersionBuild(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetAuthor(out IntPtr data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetBuildDay(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetBuildMonth(out int data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 LibraryInfo_GetBuildYear(out int data);
+
+        #endregion
+
         #region Logging
 
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]

--- a/src/vanillapdf.net/Interop/NativeMethods.Core.LibraryImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Core.LibraryImport.cs
@@ -44,6 +44,34 @@ namespace vanillapdf.net.Interop
 
         #endregion
 
+        #region LibraryInfo
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetVersionMajor(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetVersionMinor(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetVersionPatch(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetVersionBuild(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetAuthor(out IntPtr data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetBuildDay(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetBuildMonth(out int data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 LibraryInfo_GetBuildYear(out int data);
+
+        #endregion
+
         #region Logging
 
         [LibraryImport(LibraryName)]

--- a/src/vanillapdf.net/PdfUtils/PdfLibraryInfo.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfLibraryInfo.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Runtime.InteropServices;
+using vanillapdf.net.Interop;
+
+namespace vanillapdf.net.PdfUtils
+{
+    /// <summary>
+    /// Information about the native Vanilla.PDF library version, build and author.
+    /// </summary>
+    public static class PdfLibraryInfo
+    {
+        /// <summary>
+        /// Library major version.
+        /// A change in the major version indicates backward incompatibility.
+        /// </summary>
+        public static int VersionMajor {
+            get { return GetVersionMajor(); }
+        }
+
+        /// <summary>
+        /// Library minor version.
+        /// A change in the minor version indicates backward compatibility, while some new features were added.
+        /// </summary>
+        public static int VersionMinor {
+            get { return GetVersionMinor(); }
+        }
+
+        /// <summary>
+        /// Library patch version.
+        /// A change in the patch version indicates no interface changes, only bugfixes.
+        /// </summary>
+        public static int VersionPatch {
+            get { return GetVersionPatch(); }
+        }
+
+        /// <summary>
+        /// Library build version.
+        /// A change in the build version should not affect any kind of functionality.
+        /// </summary>
+        public static int VersionBuild {
+            get { return GetVersionBuild(); }
+        }
+
+        /// <summary>
+        /// Library author name.
+        /// </summary>
+        public static string Author {
+            get { return GetAuthor(); }
+        }
+
+        /// <summary>
+        /// Day of month when the library was built.
+        /// </summary>
+        public static int BuildDay {
+            get { return GetBuildDay(); }
+        }
+
+        /// <summary>
+        /// Month of the year when the library was built.
+        /// </summary>
+        public static int BuildMonth {
+            get { return GetBuildMonth(); }
+        }
+
+        /// <summary>
+        /// Year when the library was built.
+        /// </summary>
+        public static int BuildYear {
+            get { return GetBuildYear(); }
+        }
+
+        private static int GetVersionMajor()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetVersionMajor(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static int GetVersionMinor()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetVersionMinor(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static int GetVersionPatch()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetVersionPatch(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static int GetVersionBuild()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetVersionBuild(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static string GetAuthor()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetAuthor(out IntPtr data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            // The author is a static, null-terminated ASCII string owned by the
+            // native library, so the memory must not be freed here.
+            return Marshal.PtrToStringAnsi(data);
+        }
+
+        private static int GetBuildDay()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetBuildDay(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static int GetBuildMonth()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetBuildMonth(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+
+        private static int GetBuildYear()
+        {
+            UInt32 result = NativeMethods.LibraryInfo_GetBuildYear(out int data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing `LibraryInfo` bindings as a new `PdfLibraryInfo` static class in `PdfUtils`, wrapping the native `c_library_info.h` API.

Exposed properties:
- `VersionMajor` / `VersionMinor` / `VersionPatch` / `VersionBuild` — native library version
- `Author` — library author name
- `BuildDay` / `BuildMonth` / `BuildYear` — build date

## Implementation notes

- P/Invoke declarations added to both `NativeMethods.Core.DllImport.cs` (.NET Standard 2.0) and `NativeMethods.Core.LibraryImport.cs` (.NET 7+), mirroring the existing `LicenseInfo` region.
- Integer getters use `out int` (`integer_type` = `int32_t`).
- `Author` returns a static, null-terminated ASCII string (`string_type`) owned by the native library; marshaled with `Marshal.PtrToStringAnsi` (works on both target frameworks) and not freed.
- Properties delegate to private getter methods, consistent with the existing accessor style.

## Testing

Added `PdfLibraryInfoTest` covering version, author, and build-date getters. All tests pass on net9.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)