### PR TITLE
ci: Replace CodeQL default setup with advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+# CodeQL advanced setup.
+#
+# Replaces GitHub "default setup" so that code scanning also runs on pull
+# requests targeting release branches (default setup only scans the default
+# branch and PRs into it). The branch rulesets require a CodeQL result before a
+# PR can merge, so release backports were blocked without this.
+
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release/*"
+
+  pull_request:
+    branches:
+      - "main"
+      - "release/*"
+
+  schedule:
+    # Weekly, matching the previous default-setup cadence.
+    - cron: "23 4 * * 1"
+
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: analyze-${{ matrix.language }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: csharp
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Switches CodeQL from GitHub **default setup** to an **advanced workflow** (`.github/workflows/codeql.yml`).

**Why:** Default setup only analyzes the default branch (`main`) and PRs targeting it. PRs into `release/*` were never scanned, so the `code_scanning` rule in the *Protect release branches* ruleset could never be satisfied — permanently blocking release backports such as #109 (`MERGEABLE` but `mergeStateStatus: BLOCKED`, no bypass actors).

**What:** The new workflow runs on `push` and `pull_request` for both `main` and `release/*`, plus a weekly schedule, covering the same languages as the previous default setup (`actions`, `csharp`) with `build-mode: none`.

Default setup has been disabled (it is mutually exclusive with an advanced workflow).

## Follow-ups
- Backport this workflow to `release/2.2` so backport PRs there get scanned.
- Re-trigger CodeQL on #109 once the workflow exists on the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)