### PR TITLE
Set VersionPrefix to 2.3.0 for the 2.3.0-beta.1 release

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -14,7 +14,7 @@
     <PublishTrimmed Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishTrimmed>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <VersionPrefix>2.3.0-beta.1</VersionPrefix>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Title>vanillapdf.net</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>
     <PackageProjectUrl>https://vanillapdf.com/</PackageProjectUrl>


### PR DESCRIPTION
## Summary

Prepares the `2.3.0-beta.1` release by fixing the package version prefix.

`<VersionPrefix>` was set to `2.3.0-beta.1`, which breaks the release pipeline:
- The `verify` job in `release.yml` compares the tag's base version (`2.3.0`) against `<VersionPrefix>` and fails on mismatch.
- The pack step already appends the pre-release label via `--version-suffix` derived from the tag, so the current prefix would produce a doubled `2.3.0-beta.1-beta.1`.

This sets `<VersionPrefix>` to the numeric-only `2.3.0`, matching prior releases (`v2.2.0`, `v2.2.1`). The `beta.1` suffix comes from the `v2.3.0-beta.1` tag at pack time.

After this merges, tagging `v2.3.0-beta.1` triggers the release: build → GitHub Packages (staging) → production approval gate → nuget.org (OIDC) → draft GitHub prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)