### PR TITLE
Disable GeneratePackageOnBuild to fix NU5104 on pre-release native dependency

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -13,7 +13,13 @@
     <PublishAot Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishAot>
     <PublishTrimmed Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishTrimmed>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- Package only via an explicit `dotnet pack`, which supplies the pre-release
+         label through --version-suffix from the release/nightly tag. Packing on
+         every build would instead use the bare VersionPrefix (a stable version),
+         tripping NU5104 whenever the native vanillapdf dependency is a pre-release
+         (a stable package must not depend on a pre-release). This has no effect on
+         normal build output (the DLL is still produced). -->
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <VersionPrefix>2.3.0</VersionPrefix>
     <Title>vanillapdf.net</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>

--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -14,11 +14,11 @@
     <PublishTrimmed Condition="'$(TargetFramework)' == 'netstandard2.0'">false</PublishTrimmed>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Package only via an explicit `dotnet pack`, which supplies the pre-release
-         label through --version-suffix from the release/nightly tag. Packing on
-         every build would instead use the bare VersionPrefix (a stable version),
-         tripping NU5104 whenever the native vanillapdf dependency is a pre-release
-         (a stable package must not depend on a pre-release). This has no effect on
-         normal build output (the DLL is still produced). -->
+         label through the version-suffix option from the release/nightly tag.
+         Packing on every build would instead use the bare VersionPrefix (a stable
+         version), tripping NU5104 whenever the native vanillapdf dependency is a
+         pre-release (a stable package must not depend on a pre-release). This has
+         no effect on normal build output (the DLL is still produced). -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <VersionPrefix>2.3.0</VersionPrefix>
     <Title>vanillapdf.net</Title>


### PR DESCRIPTION
## Summary

Fixes the build failure introduced when `<VersionPrefix>` became the numeric-only `2.3.0` (#115).

`GeneratePackageOnBuild=true` packs the project on every `dotnet build`/`dotnet test`, but a plain build does **not** apply `--version-suffix` (that lives only on the explicit `dotnet pack`). The on-build package is therefore versioned `2.3.0` (stable) while depending on the pre-release `vanillapdf 2.3.0-beta.1`, which trips **NU5104** ("a stable release of a package should not have a prerelease dependency"). With `TreatWarningsAsErrors=true`, that fails sanity-check, nightly, and release builds.

## Fix

Set `GeneratePackageOnBuild=false` (the MSBuild default). Packaging now happens **only** via the explicit `dotnet pack --version-suffix <suffix>` step in `build-nuget.yml`, so the produced package is itself pre-release (`2.3.0-beta.1`) and NU5104 does not apply. Normal build output (the DLL) is unchanged.

After this merges, re-tagging `v2.3.0-beta.1` will run the release pipeline cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)