### PR TITLE
Bump vanillapdf native dependency to 2.3.0-rc.1

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -76,7 +76,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.3.0-beta.1" />
+    <PackageReference Include="vanillapdf" Version="2.3.0-rc.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps the `vanillapdf` native `PackageReference` from `2.3.0-beta.1` to `2.3.0-rc.1`.

rc.1 adds:
- The symmetric `ContentObjectInlineImage_ToContentObject` / `_FromContentObject` cast functions (`ContentObject_ToInlineImage` is now deprecated in favor of `_FromContentObject`)
- `Buffer_CreateFromData` / `Buffer_SetData` acceptance of a null pointer with zero length

This is the prerequisite for the two rc.1-gated feature branches, which will be rebased onto `main` once this merges:
- `feature/inline-image-data` — #120
- `feature/buffer-empty-data` — #121

**Verification:** builds clean; all 228 tests pass against 2.3.0-rc.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)