### PR TITLE
Remove empty-span sentinel in PdfBuffer

### DIFF
--- a/src/vanillapdf.net.nunit/PdfUtils/PdfBufferTest.cs
+++ b/src/vanillapdf.net.nunit/PdfUtils/PdfBufferTest.cs
@@ -35,6 +35,22 @@ namespace vanillapdf.net.nunit.PdfUtils
         }
 
         [Test]
+        public void TestCreateFromDataEmpty()
+        {
+            using var buffer = PdfBuffer.CreateFromData(new byte[0]);
+
+            ClassicAssert.AreEqual(0, buffer.Data.Length);
+        }
+
+        [Test]
+        public void TestCreateFromEmptySpan()
+        {
+            using var buffer = PdfBuffer.CreateFromData(ReadOnlySpan<byte>.Empty);
+
+            ClassicAssert.AreEqual(0, buffer.Data.Length);
+        }
+
+        [Test]
         public void TestDataString()
         {
             const string TEST_DATA = "TEST_DATA";

--- a/src/vanillapdf.net/PdfUtils/PdfBuffer.cs
+++ b/src/vanillapdf.net/PdfUtils/PdfBuffer.cs
@@ -115,18 +115,8 @@ namespace vanillapdf.net.PdfUtils
         /// <returns>New instance of \ref PdfBuffer on success, throws exception on failure</returns>
         public static unsafe PdfBuffer CreateFromData(ReadOnlySpan<byte> data)
         {
-            // Use a sentinel for empty spans to get a valid pointer
-            // (native code doesn't accept IntPtr.Zero even for zero-length data)
-            if (data.IsEmpty) {
-                byte sentinel = 0;
-                UInt32 emptyResult = NativeMethods.Buffer_CreateFromData((IntPtr)(&sentinel), UIntPtr.Zero, out PdfBufferSafeHandle emptyHandle);
-                if (emptyResult != PdfReturnValues.ERROR_SUCCESS) {
-                    throw PdfErrors.GetLastErrorException();
-                }
-
-                return new PdfBuffer(emptyHandle);
-            }
-
+            // An empty span yields a null pointer from fixed; native accepts a
+            // null pointer with zero length, so no sentinel is required.
             fixed (byte* ptr = data) {
                 UInt32 result = NativeMethods.Buffer_CreateFromData((IntPtr)ptr, new UIntPtr((uint)data.Length), out PdfBufferSafeHandle handle);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
@@ -189,17 +179,8 @@ namespace vanillapdf.net.PdfUtils
             lock (_syncLock) {
                 if (_disposed) throw new ObjectDisposedException(nameof(PdfBuffer));
 
-                // Use a sentinel for empty spans to get a valid pointer
-                // (native code doesn't accept IntPtr.Zero even for zero-length data)
-                if (data.IsEmpty) {
-                    byte sentinel = 0;
-                    UInt32 emptyResult = NativeMethods.Buffer_SetData(Handle, (IntPtr)(&sentinel), UIntPtr.Zero);
-                    if (emptyResult != PdfReturnValues.ERROR_SUCCESS) {
-                        throw PdfErrors.GetLastErrorException();
-                    }
-                    return;
-                }
-
+                // An empty span yields a null pointer from fixed; native accepts a
+                // null pointer with zero length, so no sentinel is required.
                 fixed (byte* ptr = data) {
                     UInt32 result = NativeMethods.Buffer_SetData(Handle, (IntPtr)ptr, new UIntPtr((uint)data.Length));
                     if (result != PdfReturnValues.ERROR_SUCCESS) {


### PR DESCRIPTION
Native `vanillapdf` 2.3.0-rc.1 (already on `main`) accepts a null pointer with zero length in `Buffer_CreateFromData` / `Buffer_SetData`, so the stack `sentinel` byte workaround for empty spans is no longer needed. A `fixed` statement already yields a null pointer for an empty span, so both `CreateFromData` and `SetData` collapse to the single `fixed` path.

## Changes
- Remove the empty-span sentinel branches in `PdfBuffer.CreateFromData(ReadOnlySpan<byte>)` and `SetData(ReadOnlySpan<byte>)` (−23/+4)
- Add tests covering `CreateFromData(new byte[0])` and `CreateFromData(ReadOnlySpan<byte>.Empty)`

## Notes
- Verified: full suite passes (243 tests) on rc.1.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)