### PR TITLE
Release: create the tag by publishing the draft, not up front

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,5 +1,9 @@
 name: Create GitHub Release
 
+# Creates the GitHub release as a DRAFT. The tag is intentionally not created
+# here: publishing the draft (done later by release.yml, after the production
+# gate) is what creates the tag at `target` and binds the release to it.
+
 on:
   workflow_call:
     inputs:
@@ -9,11 +13,20 @@ on:
       prerelease:
         required: true
         type: boolean
+      latest:
+        required: false
+        type: boolean
+        default: true
+      target:
+        description: "Commit SHA the tag is created at when the draft is published"
+        required: false
+        type: string
+        default: ''
 
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag name (e.g., v2.0.0)"
+        description: "Tag name (e.g., v2.3.0)"
         required: true
         type: string
       prerelease:
@@ -21,14 +34,25 @@ on:
         required: true
         type: boolean
         default: false
+      latest:
+        description: "Mark as the latest release?"
+        required: false
+        type: boolean
+        default: true
+      target:
+        description: "Commit SHA the tag is created at when the draft is published"
+        required: false
+        type: string
+        default: ''
 
-permissions:
-  contents: write  # Required to create a release
+permissions: {}
 
 jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to create a release
 
     steps:
       - name: Checkout code
@@ -36,27 +60,36 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release from tag
+      - name: Create draft release
         env:
           TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ inputs.prerelease }}
+          LATEST: ${{ inputs.latest }}
+          TARGET: ${{ inputs.target }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
         run: |
           echo "Creating draft release for tag: $TAG"
           if gh release view "$TAG" &>/dev/null; then
             echo "Release $TAG already exists. Skipping."
             exit 0
           fi
+
+          # The tag must NOT exist yet: publishing this draft is what creates the
+          # tag (at TARGET) and binds the release to it. Pre-creating the tag
+          # would leave the published release stuck on its untagged placeholder.
+          FLAGS=()
           if [ "$PRERELEASE" = "true" ]; then
-            gh release create "$TAG" \
-              --title "vanillapdf $TAG" \
-              --generate-notes \
-              --draft \
-              --prerelease
-          else
-            gh release create "$TAG" \
-              --title "vanillapdf $TAG" \
-              --generate-notes \
-              --draft
+            FLAGS+=(--prerelease)
           fi
+          if [ "$LATEST" = "false" ]; then
+            FLAGS+=(--latest=false)
+          fi
+          if [ -n "$TARGET" ]; then
+            FLAGS+=(--target "$TARGET")
+          fi
+
+          gh release create "$TAG" \
+            --title "vanillapdf $TAG" \
+            --generate-notes \
+            --draft \
+            "${FLAGS[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,30 +199,26 @@ jobs:
       target: ${{ github.sha }}
     secrets: inherit
 
-  production-gate:
+  # Single production gate. The `production` environment's required reviewer and
+  # wait timer pause the run here, giving a human the window to edit the draft
+  # release body before approving. On approval this one job does the whole
+  # publish: publishing the draft creates the tag (via BOT_TOKEN, so it passes
+  # the tag-protection ruleset), then the package is pushed to NuGet.org via
+  # OIDC trusted publishing. Keeping it a single environment job means exactly
+  # one approval, not one per publish step.
+  publish:
     runs-on: ubuntu-latest
-    permissions: {}
     needs: [create-draft-release, prepare]
+    if: needs.prepare.outputs.dry_run == 'false'
     environment: production
-    outputs:
-      tag: ${{ needs.prepare.outputs.tag }}
-      is_latest: ${{ needs.prepare.outputs.is_latest }}
-    steps:
-      - run: echo "Draft release created. Edit the release body in the UI, then approve to publish."
-
-  # Flip the reviewed draft to a published release. Publishing creates the tag at
-  # the draft's target commit and binds the release to it. BOT_TOKEN is used so
-  # the tag is created under the repository's tag protection ruleset.
-  publish-release:
-    runs-on: ubuntu-latest
     permissions:
-      contents: write
-    needs: production-gate
+      contents: write  # create the tag by publishing the draft
+      id-token: write  # GitHub OIDC token for NuGet trusted publishing
     steps:
-      - name: Publish draft release
+      - name: Publish draft release (creates the tag)
         env:
-          TAG: ${{ needs.production-gate.outputs.tag }}
-          IS_LATEST: ${{ needs.production-gate.outputs.is_latest }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          IS_LATEST: ${{ needs.prepare.outputs.is_latest }}
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
@@ -232,13 +228,6 @@ jobs:
           fi
           gh release edit "$TAG" --draft=false $LATEST_FLAG
 
-  publish-nuget:
-    runs-on: ubuntu-latest
-    needs: publish-release
-    environment: production
-    permissions:
-      id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
-    steps:
       - name: Download NuGet packages
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           # tag yet, so derive a synthetic one from the csproj VersionPrefix -
           # enough to exercise the build/verify path in dry-run mode.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE=$(grep -oP '<VersionPrefix>\K[^<]+' src/vanillapdf.net/vanillapdf.net.csproj)
+            BASE=$(sed -n 's:.*<VersionPrefix>\(.*\)</VersionPrefix>.*:\1:p' src/vanillapdf.net/vanillapdf.net.csproj)
             TAG="v${BASE}"
           else
             TAG="${{ inputs.tag }}"
@@ -67,6 +67,16 @@ jobs:
 
           # Any suffix after MAJOR.MINOR.PATCH (e.g. -rc.1) marks a pre-release.
           VERSION="${TAG#v}"
+
+          # Fail fast on a malformed version, whatever the source (csproj or input
+          # tag). Encodes the tag scheme from RELEASE-GUIDE.md, so a bad core or a
+          # malformed suffix (e.g. -rc1, -RC.1) is rejected here rather than at pack
+          # or tag-creation time.
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; then
+            echo "::error::Version '$VERSION' is not valid: expected X.Y.Z or X.Y.Z-(alpha|beta|rc).N"
+            exit 1
+          fi
+
           EXTRA=""
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)$ ]]; then
             EXTRA="${BASH_REMATCH[1]}"
@@ -117,14 +127,11 @@ jobs:
           # Strip any pre-release suffix (e.g. 2.3.0-rc.1 -> 2.3.0)
           BASE_VERSION=$(echo "$VERSION" | cut -d- -f1)
 
-          # csproj VersionPrefix is the source of truth for the release version
-          CSPROJ_VERSION=$(grep -oP '<VersionPrefix>\K[^<]+' src/vanillapdf.net/vanillapdf.net.csproj)
-
-          echo "Tag version: $BASE_VERSION"
-          echo "csproj VersionPrefix: $CSPROJ_VERSION"
-
-          if [ "$BASE_VERSION" != "$CSPROJ_VERSION" ]; then
-            echo "::error::Version mismatch: tag=$BASE_VERSION, csproj=$CSPROJ_VERSION"
+          # csproj VersionPrefix is the source of truth. Assert the expected value
+          # is present rather than re-extracting and comparing, so there is nothing
+          # to normalize and a mismatch simply fails.
+          if ! grep -qF "<VersionPrefix>${BASE_VERSION}</VersionPrefix>" src/vanillapdf.net/vanillapdf.net.csproj; then
+            echo "::error::Version mismatch: tag base $BASE_VERSION not found as <VersionPrefix> in csproj"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,110 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - 'v*.*.*'
+# Release orchestration for the vanillapdf.net NuGet package.
+#
+# Unlike a tag-triggered pipeline, this workflow does NOT run on `push: tags`.
+# The tag is created last, by *publishing* the draft GitHub release, so it only
+# comes into existence after every build/validation step and a human review of
+# the release body have passed. See RELEASE-GUIDE.md for the full procedure.
+#
+# Triggers:
+#   * workflow_dispatch - real releases (and manual dry runs). The tag is
+#     supplied as an input; `dry_run` defaults to true.
+#   * pull_request      - validation only. Any change to the release workflows
+#     runs the build/verify path with a synthetic tag derived from the csproj
+#     VersionPrefix, never publishing or tagging.
 
-permissions:
-  contents: write
-  packages: write
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/build-nuget.yml'
+      - '.github/workflows/github-release.yml'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag name to create (e.g. v2.3.0-rc.1)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run - validate without publishing or tagging"
+        required: false
+        type: boolean
+        default: true
+
+permissions: {}
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.parse.outputs.tag }}
       build_suffix: ${{ steps.parse.outputs.build_suffix }}
       prerelease: ${{ steps.parse.outputs.prerelease }}
+      is_latest: ${{ steps.parse.outputs.is_latest }}
+      dry_run: ${{ steps.parse.outputs.dry_run }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       - name: Extract tag name and suffix
         id: parse
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          # Determine the tag based on the trigger. On pull_request there is no
+          # tag yet, so derive a synthetic one from the csproj VersionPrefix -
+          # enough to exercise the build/verify path in dry-run mode.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE=$(grep -oP '<VersionPrefix>\K[^<]+' src/vanillapdf.net/vanillapdf.net.csproj)
+            TAG="v${BASE}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          # Any suffix after MAJOR.MINOR.PATCH (e.g. -rc.1) marks a pre-release.
           VERSION="${TAG#v}"
           EXTRA=""
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(.*)$ ]]; then
             EXTRA="${BASH_REMATCH[1]}"
           fi
           if [[ -n "$EXTRA" ]]; then
-            EXTRA="${EXTRA#-}"
-            echo "build_suffix=$EXTRA" >> "$GITHUB_OUTPUT"
+            echo "build_suffix=${EXTRA#-}" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "build_suffix=" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
+          # pull_request is always a dry run; workflow_dispatch honors the input.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Decide whether this is the newest stable release. The tag being
+          # released does not exist as a git ref yet (it is created when the
+          # draft is published), so compare the existing stable tags *plus* this
+          # tag. Pre-releases are never marked latest.
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            HIGHEST=$( { git tag -l 'v*.*.*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'; echo "$TAG"; } | sort -V | tail -1)
+            if [ "$HIGHEST" = "$TAG" ]; then
+              echo "is_latest=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_latest=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: prepare
     steps:
       - uses: actions/checkout@v7
@@ -47,10 +114,10 @@ jobs:
           TAG="${{ needs.prepare.outputs.tag }}"
           VERSION="${TAG#v}"
 
-          # Strip any pre-release suffix (e.g., 2.2.0-rc1 -> 2.2.0)
+          # Strip any pre-release suffix (e.g. 2.3.0-rc.1 -> 2.3.0)
           BASE_VERSION=$(echo "$VERSION" | cut -d- -f1)
 
-          # Read VersionPrefix from csproj
+          # csproj VersionPrefix is the source of truth for the release version
           CSPROJ_VERSION=$(grep -oP '<VersionPrefix>\K[^<]+' src/vanillapdf.net/vanillapdf.net.csproj)
 
           echo "Tag version: $BASE_VERSION"
@@ -65,14 +132,21 @@ jobs:
 
   build-nuget:
     needs: [verify, prepare]
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/build-nuget.yml
     with:
       build_suffix: ${{ needs.prepare.outputs.build_suffix }}
+    secrets: inherit
 
   nuget-staging:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     environment: staging
-    needs: build-nuget
+    needs: [build-nuget, prepare]
+    if: needs.prepare.outputs.dry_run == 'false'
     steps:
       - name: Download NuGet packages
         uses: actions/download-artifact@v8
@@ -86,16 +160,81 @@ jobs:
             --api-key "${{ secrets.GITHUB_TOKEN }}" \
             --skip-duplicate
 
+  dry-run-report:
+    runs-on: ubuntu-latest
+    permissions: {}
+    needs: [build-nuget, prepare]
+    if: always() && needs.prepare.outputs.dry_run == 'true'
+    steps:
+      - name: Dry run summary
+        run: |
+          echo "=== Dry Run Summary ==="
+          echo "Tag:          ${{ needs.prepare.outputs.tag }}"
+          echo "Build suffix: ${{ needs.prepare.outputs.build_suffix }}"
+          echo "Prerelease:   ${{ needs.prepare.outputs.prerelease }}"
+          echo "Is latest:    ${{ needs.prepare.outputs.is_latest }}"
+          echo "NuGet build:  ${{ needs.build-nuget.result }}"
+          echo ""
+          if [ "${{ needs.build-nuget.result }}" != "success" ]; then
+            echo "::error::Dry-run validation failed (build-nuget did not succeed)"
+            exit 1
+          fi
+          echo "=== All dry-run validations passed ==="
+
+  # Create the GitHub release as a *draft* before the production gate. The tag is
+  # deliberately not created here - publishing the draft (publish-release, after
+  # the gate) is what creates it at `target`. This lets a human edit the release
+  # body during the gate pause, and avoids binding the release to a pre-existing
+  # tag before the draft is finalized.
+  create-draft-release:
+    needs: [nuget-staging, prepare]
+    if: needs.prepare.outputs.dry_run == 'false'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/github-release.yml
+    with:
+      tag: ${{ needs.prepare.outputs.tag }}
+      prerelease: ${{ fromJSON(needs.prepare.outputs.prerelease) }}
+      latest: ${{ fromJSON(needs.prepare.outputs.is_latest) }}
+      target: ${{ github.sha }}
+    secrets: inherit
+
   production-gate:
     runs-on: ubuntu-latest
-    needs: nuget-staging
+    permissions: {}
+    needs: [create-draft-release, prepare]
     environment: production
+    outputs:
+      tag: ${{ needs.prepare.outputs.tag }}
+      is_latest: ${{ needs.prepare.outputs.is_latest }}
     steps:
-      - run: echo "Awaiting production approval"
+      - run: echo "Draft release created. Edit the release body in the UI, then approve to publish."
+
+  # Flip the reviewed draft to a published release. Publishing creates the tag at
+  # the draft's target commit and binds the release to it. BOT_TOKEN is used so
+  # the tag is created under the repository's tag protection ruleset.
+  publish-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: production-gate
+    steps:
+      - name: Publish draft release
+        env:
+          TAG: ${{ needs.production-gate.outputs.tag }}
+          IS_LATEST: ${{ needs.production-gate.outputs.is_latest }}
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          LATEST_FLAG=""
+          if [ "$IS_LATEST" = "false" ]; then
+            LATEST_FLAG="--latest=false"
+          fi
+          gh release edit "$TAG" --draft=false $LATEST_FLAG
 
   publish-nuget:
     runs-on: ubuntu-latest
-    needs: production-gate
+    needs: publish-release
     environment: production
     permissions:
       id-token: write  # Enable GitHub OIDC token issuance for NuGet trusted publishing
@@ -120,12 +259,3 @@ jobs:
             --source "${{ vars.NUGET_SOURCE }}" \
             --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
             --skip-duplicate
-
-  github-release:
-    needs: [production-gate, prepare]
-    uses: ./.github/workflows/github-release.yml
-    with:
-      tag: ${{ needs.prepare.outputs.tag }}
-      # Convert string output to boolean (job outputs are always strings)
-      prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
-    secrets: inherit

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -1,0 +1,91 @@
+# 🧩 Vanilla.PDF .NET Release Guide
+
+This guide describes how stable and pre-release versions of the `vanillapdf.net`
+NuGet package are cut. It mirrors the release model used by the native
+[vanillapdf](https://github.com/vanillapdf/vanillapdf) project.
+
+The guiding principle: **the git tag is created last.** It only comes into
+existence when the reviewed draft release is published, after every build and
+validation step has passed. Nothing is tagged up front, so a failed build never
+leaves a dangling tag behind.
+
+---
+
+## 🏷️ Creating a Release (Pre-release or Stable)
+
+Tags are **not** created manually with `git tag` / `git push`. The `release.yml`
+workflow owns tag creation end to end.
+
+1. **Dry run.** Trigger `release.yml` via `workflow_dispatch` — from the Actions
+   tab, or:
+
+   ```bash
+   gh workflow run release.yml -f tag=v2.3.0-rc.1 -f dry_run=true
+   ```
+
+   With `dry_run: true` (the default) it builds and tests the package on every
+   supported OS and verifies the version, but publishes and tags nothing.
+
+2. **Real run.** Re-run with `dry_run: false`. This builds the package for real,
+   pushes it to the GitHub Packages staging feed, and creates the GitHub release
+   as a **draft** — still without creating the tag.
+
+3. **Review.** The `production` environment gate pauses the workflow. Review and
+   edit the draft release body in the GitHub UI, then approve the gate.
+
+4. **Publish.** Approving publishes the draft, which is what actually **creates
+   the tag** (at the commit the workflow ran on) and binds the release to it.
+   The package is then pushed to NuGet.org via OIDC trusted publishing.
+
+> Whether a tag counts as a pre-release is derived automatically from its suffix
+> (`-alpha.N`, `-beta.N`, `-rc.N`) by the `prepare` job in `release.yml`. Stable
+> tags (`vX.Y.Z` with no suffix) are additionally evaluated for whether they are
+> the newest version, which drives the GitHub "Latest" release flag.
+
+---
+
+## 📦 Version Source
+
+`<VersionPrefix>` in `src/vanillapdf.net/vanillapdf.net.csproj` is the single
+source of truth for the release version. The `verify` job fails the run if the
+tag's base version (ignoring any pre-release suffix) does not match it.
+
+So the version bump to `<VersionPrefix>` must be committed **before** triggering
+a real release. The pre-release suffix is supplied only through the tag input
+(e.g. `-rc.1`) and is applied to the package via `dotnet pack --version-suffix`.
+
+---
+
+## 🔁 Branching
+
+- Ordinary work happens on `main`; name branches `fix/...` or `feature/...`.
+- Pre-release tags (`alpha`, `beta`, `rc`) are normally cut from `main`.
+- `release/x.y` branches are reserved for long-lived release lines that receive
+  backports, and are matched by branch/tag protection rulesets. Do not use that
+  prefix for ordinary work. See `CLAUDE.md` for the full branch-naming policy.
+
+---
+
+## 🧪 Workflow Summary
+
+| Workflow | Trigger | Publishes? |
+| --- | --- | --- |
+| `release.yml` | `workflow_dispatch` (real releases) · `pull_request` (dry-run validation of workflow changes) | ✅ unless `dry_run: true` |
+| `build-nuget.yml` | called by `release.yml`; also on pushes/PRs that touch it | ❌ builds & tests only |
+| `github-release.yml` | called by `release.yml` | Creates the **draft** only; the tag is created when the draft is published |
+
+Notes:
+
+- `release.yml` has **no** `push: tags:` trigger. On `pull_request` it runs the
+  build/verify path with a synthetic tag derived from `<VersionPrefix>`, and is
+  always a dry run.
+- Publishing the draft uses `BOT_TOKEN` so the new tag is accepted under the
+  repository's tag-protection ruleset.
+- The `staging` and `production` GitHub environments provide the human approval
+  gate and scope the publishing credentials.
+
+---
+
+*Release notes themselves live on the
+[GitHub Releases page](https://github.com/vanillapdf/vanillapdf.net/releases);
+see `CHANGELOG.md`.*

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -30,12 +30,14 @@ workflow owns tag creation end to end.
    pushes it to the GitHub Packages staging feed, and creates the GitHub release
    as a **draft** — still without creating the tag.
 
-3. **Review.** The `production` environment gate pauses the workflow. Review and
-   edit the draft release body in the GitHub UI, then approve the gate.
+3. **Review.** A single `production` environment gate (wait timer + one required
+   reviewer) pauses the workflow. Review and edit the draft release body in the
+   GitHub UI, then approve.
 
-4. **Publish.** Approving publishes the draft, which is what actually **creates
-   the tag** (at the commit the workflow ran on) and binds the release to it.
-   The package is then pushed to NuGet.org via OIDC trusted publishing.
+4. **Publish.** Approving runs the one publish job: it publishes the draft —
+   which is what actually **creates the tag** (at the commit the workflow ran on)
+   and binds the release to it — and then pushes the package to NuGet.org via
+   OIDC trusted publishing. One approval covers both steps.
 
 > Whether a tag counts as a pre-release is derived automatically from its suffix
 > (`-alpha.N`, `-beta.N`, `-rc.N`) by the `prepare` job in `release.yml`. Stable


### PR DESCRIPTION
Aligns the release pipeline with the native [vanillapdf](https://github.com/vanillapdf/vanillapdf) repo so the **git tag is created last** — only after every build/validation step and a human review of the release body have passed. Requested as a follow-up to the docs work (separate from #126).

## Problem

Today `release.yml` triggers on `push: tags`. The tag therefore exists **before** anything is validated, so a failed build (or a bad version) leaves a dangling tag behind that has to be cleaned up manually.

## New flow

`release.yml` is now driven by `workflow_dispatch` (with a `pull_request` dry-run for validating workflow changes). Order of operations:

```
prepare → verify → build-nuget → nuget-staging
        → create-draft-release → production gate → publish-release → publish-nuget
```

- **No tag up front.** `github-release.yml` creates the GitHub release as a **draft** only, taking new `latest` / `target` inputs.
- **Human gate.** The `production` environment pauses the run so the release body can be edited in the UI before approval.
- **Tag created at the end.** Approving publishes the draft (`gh release edit --draft=false`), which is what creates the tag — at the workflow's commit — using `BOT_TOKEN` so it satisfies the *Protected release tags* ruleset.
- **`dry_run`** (default `true`) builds/tests/validates without publishing or tagging. The `pull_request` trigger always runs as a dry run, using a synthetic tag derived from `<VersionPrefix>`.

Adds `RELEASE-GUIDE.md` documenting the procedure.

## How to release after this

```bash
gh workflow run release.yml -f tag=v2.3.0-rc.1 -f dry_run=true   # validate
gh workflow run release.yml -f tag=v2.3.0-rc.1 -f dry_run=false  # then approve the gate
```

## Notes / prerequisites (already in place)

- `BOT_TOKEN` secret — ✅ present.
- `staging` + `production` environments — ✅ present (production provides the approval gate).
- Tag ruleset blocks delete/update but **not creation**, so publishing the draft can create a fresh `vX.Y.Z` tag.
- Opening this PR triggers `release.yml` in **dry-run** mode (it touches the release workflows), which validates the build/verify path across all OSes without publishing or tagging.
- Preserved as-is: OIDC trusted publishing to NuGet.org, GitHub Packages staging, and the per-environment `NUGET_SOURCE` variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)