### PR TITLE
Add ViewerPreferences and PageLayout catalog bindings

### DIFF
--- a/src/vanillapdf.net.nunit/PdfSemantics/PdfViewerPreferencesTest.cs
+++ b/src/vanillapdf.net.nunit/PdfSemantics/PdfViewerPreferencesTest.cs
@@ -1,0 +1,140 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.IO;
+using vanillapdf.net.PdfSemantics;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+
+namespace vanillapdf.net.nunit.PdfSemantics
+{
+    [TestFixture]
+    public class PdfViewerPreferencesTest
+    {
+        // ViewerPreferences << /CenterWindow true >>
+        private const string CenterWindowPdf = "20131231103232738561744.pdf";
+
+        // Empty ViewerPreferences << >>
+        private const string EmptyPrefsPdf = "Granizo.pdf";
+
+        // /PageLayout /OneColumn
+        private const string PageLayoutPdf = "19005-1_FAQ.PDF";
+
+        #region PageLayout
+
+        [Test]
+        public void TestGetPageLayoutOneColumn()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", PageLayoutPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            ClassicAssert.AreEqual(PdfPageLayoutType.OneColumn, catalog.GetPageLayout());
+        }
+
+        [Test]
+        public void TestGetPageLayoutAbsentReturnsNull()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", CenterWindowPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            ClassicAssert.IsNull(catalog.GetPageLayout());
+        }
+
+        [Test]
+        public void TestPageLayoutEnumValues()
+        {
+            ClassicAssert.AreEqual(0, (int)PdfPageLayoutType.Undefined);
+            ClassicAssert.AreEqual(1, (int)PdfPageLayoutType.SinglePage);
+            ClassicAssert.AreEqual(2, (int)PdfPageLayoutType.OneColumn);
+            ClassicAssert.AreEqual(3, (int)PdfPageLayoutType.TwoColumnLeft);
+            ClassicAssert.AreEqual(4, (int)PdfPageLayoutType.TwoColumnRight);
+            ClassicAssert.AreEqual(5, (int)PdfPageLayoutType.TwoPageLeft);
+            ClassicAssert.AreEqual(6, (int)PdfPageLayoutType.TwoPageRight);
+        }
+
+        #endregion
+
+        #region ViewerPreferences
+
+        [Test]
+        public void TestGetViewerPreferencesReturnsObject()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", CenterWindowPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            using var preferences = catalog.GetViewerPreferences();
+            ClassicAssert.IsNotNull(preferences);
+        }
+
+        [Test]
+        public void TestViewerPreferencesCenterWindow()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", CenterWindowPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            using var preferences = catalog.GetViewerPreferences();
+            ClassicAssert.IsNotNull(preferences);
+
+            using var centerWindow = preferences.CenterWindow;
+            ClassicAssert.IsNotNull(centerWindow);
+            ClassicAssert.IsTrue(centerWindow.Value);
+        }
+
+        [Test]
+        public void TestViewerPreferencesAbsentEntriesReturnNull()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", CenterWindowPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            using var preferences = catalog.GetViewerPreferences();
+            ClassicAssert.IsNotNull(preferences);
+
+            // Only CenterWindow is present in this document.
+            ClassicAssert.IsNull(preferences.HideToolbar);
+            ClassicAssert.IsNull(preferences.FitWindow);
+            ClassicAssert.IsNull(preferences.PrintScaling);
+            ClassicAssert.IsNull(preferences.NumCopies);
+        }
+
+        [Test]
+        public void TestViewerPreferencesEmptyDictionary()
+        {
+            using var sourceStream = PdfInputOutputStream.CreateFromFile(Path.Combine("Resources", EmptyPrefsPdf));
+            using var file = PdfFile.OpenStream(sourceStream, "sourceStream");
+            file.Initialize();
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+
+            using var preferences = catalog.GetViewerPreferences();
+            ClassicAssert.IsNotNull(preferences);
+
+            // Empty dictionary: every entry is absent.
+            ClassicAssert.IsNull(preferences.CenterWindow);
+            ClassicAssert.IsNull(preferences.HideToolbar);
+            ClassicAssert.IsNull(preferences.Direction);
+            ClassicAssert.IsNull(preferences.Duplex);
+        }
+
+        #endregion
+    }
+}

--- a/src/vanillapdf.net/Interop/NativeMethods.Semantics.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Semantics.DllImport.cs
@@ -144,6 +144,67 @@ namespace vanillapdf.net.Interop
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 Catalog_GetAcroForm(PdfCatalogSafeHandle handle, out PdfInteractiveFormSafeHandle data);
 
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 Catalog_GetPageLayout(PdfCatalogSafeHandle handle, out Int32 data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 Catalog_GetViewerPreferences(PdfCatalogSafeHandle handle, out PdfViewerPreferencesSafeHandle data);
+
+        #endregion
+
+        #region ViewerPreferences
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_Release(IntPtr handle);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetHideToolbar(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetHideMenubar(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetHideWindowUI(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetFitWindow(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetCenterWindow(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetDisplayDocTitle(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetNonFullScreenPageMode(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetDirection(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetViewArea(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetViewClip(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetPrintArea(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetPrintClip(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetPrintScaling(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetDuplex(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetPickTrayByPDFSize(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 ViewerPreferences_GetNumCopies(PdfViewerPreferencesSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
         #endregion
 
         #region InteractiveForm

--- a/src/vanillapdf.net/Interop/NativeMethods.Semantics.LibraryImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Semantics.LibraryImport.cs
@@ -131,6 +131,67 @@ namespace vanillapdf.net.Interop
         [LibraryImport(LibraryName)]
         public static partial UInt32 Catalog_GetAcroForm(PdfCatalogSafeHandle handle, out PdfInteractiveFormSafeHandle data);
 
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 Catalog_GetPageLayout(PdfCatalogSafeHandle handle, out Int32 data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 Catalog_GetViewerPreferences(PdfCatalogSafeHandle handle, out PdfViewerPreferencesSafeHandle data);
+
+        #endregion
+
+        #region ViewerPreferences
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_Release(IntPtr handle);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetHideToolbar(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetHideMenubar(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetHideWindowUI(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetFitWindow(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetCenterWindow(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetDisplayDocTitle(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetNonFullScreenPageMode(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetDirection(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetViewArea(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetViewClip(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetPrintArea(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetPrintClip(PdfViewerPreferencesSafeHandle handle, out PdfNameObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetPrintScaling(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetDuplex(PdfViewerPreferencesSafeHandle handle, out Int32 data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetPickTrayByPDFSize(PdfViewerPreferencesSafeHandle handle, out PdfBooleanObjectSafeHandle data);
+
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 ViewerPreferences_GetNumCopies(PdfViewerPreferencesSafeHandle handle, out PdfIntegerObjectSafeHandle data);
+
         #endregion
 
         #region InteractiveForm

--- a/src/vanillapdf.net/PdfSemantics/PdfCatalog.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfCatalog.cs
@@ -172,6 +172,43 @@ namespace vanillapdf.net.PdfSemantics
             return new PdfAcroForm(data);
         }
 
+        /// <summary>
+        /// The page layout to be used when the document is opened.
+        /// </summary>
+        /// <returns>The <see cref="PdfPageLayoutType"/> value, or <c>null</c> if not specified.</returns>
+        public PdfPageLayoutType? GetPageLayout()
+        {
+            UInt32 result = NativeMethods.Catalog_GetPageLayout(Handle, out int data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return EnumUtil<PdfPageLayoutType>.CheckedCast(data);
+        }
+
+        /// <summary>
+        /// Retrieve the viewer preferences dictionary, controlling how the document
+        /// shall be presented on the screen or in print.
+        /// </summary>
+        /// <returns>The <see cref="PdfViewerPreferences"/> object or <c>null</c> if none exists.</returns>
+        public PdfViewerPreferences GetViewerPreferences()
+        {
+            UInt32 result = NativeMethods.Catalog_GetViewerPreferences(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return new PdfViewerPreferences(data);
+        }
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/src/vanillapdf.net/PdfSemantics/PdfDuplex.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDuplex.cs
@@ -1,0 +1,23 @@
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// The paper handling option that shall be used
+    /// when printing the file from the print dialog.
+    /// </summary>
+    public enum PdfDuplex
+    {
+        /// <summary>
+        /// Undefined uninitialized default value, triggers error when used.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>Print single-sided.</summary>
+        Simplex = 0,
+
+        /// <summary>Duplex and flip on the short edge of the sheet.</summary>
+        DuplexFlipShortEdge,
+
+        /// <summary>Duplex and flip on the long edge of the sheet.</summary>
+        DuplexFlipLongEdge,
+    };
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfNonFullScreenPageMode.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfNonFullScreenPageMode.cs
@@ -1,0 +1,26 @@
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// The document's page mode, specifying how to display
+    /// the document on exiting full-screen mode.
+    /// </summary>
+    public enum PdfNonFullScreenPageMode
+    {
+        /// <summary>
+        /// Undefined uninitialized default value, triggers error when used.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>Neither document outline nor thumbnail images visible.</summary>
+        UseNone,
+
+        /// <summary>Document outline visible.</summary>
+        UseOutlines,
+
+        /// <summary>Thumbnail images visible.</summary>
+        UseThumbs,
+
+        /// <summary>Optional content group panel visible.</summary>
+        UseOC,
+    };
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfPageLayoutType.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfPageLayoutType.cs
@@ -1,0 +1,32 @@
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// A name object specifying the page layout to be used when
+    /// the document is opened.
+    /// </summary>
+    public enum PdfPageLayoutType
+    {
+        /// <summary>
+        /// Undefined uninitialized default value, triggers error when used.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>Display one page at a time.</summary>
+        SinglePage,
+
+        /// <summary>Display the pages in one column.</summary>
+        OneColumn,
+
+        /// <summary>Display the pages in two columns, with odd-numbered pages on the left.</summary>
+        TwoColumnLeft,
+
+        /// <summary>Display the pages in two columns, with odd-numbered pages on the right.</summary>
+        TwoColumnRight,
+
+        /// <summary>(PDF 1.5) Display the pages two at a time, with odd-numbered pages on the left.</summary>
+        TwoPageLeft,
+
+        /// <summary>(PDF 1.5) Display the pages two at a time, with odd-numbered pages on the right.</summary>
+        TwoPageRight,
+    };
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfPrintScaling.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfPrintScaling.cs
@@ -1,0 +1,20 @@
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// The page scaling option that shall be selected when
+    /// a print dialog is displayed for this document.
+    /// </summary>
+    public enum PdfPrintScaling
+    {
+        /// <summary>
+        /// Undefined uninitialized default value, triggers error when used.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>Indicates the conforming reader's default print scaling.</summary>
+        AppDefault,
+
+        /// <summary>No page scaling.</summary>
+        None,
+    };
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfReadingOrder.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfReadingOrder.cs
@@ -1,0 +1,22 @@
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// The predominant reading order for text.
+    /// </summary>
+    public enum PdfReadingOrder
+    {
+        /// <summary>
+        /// Undefined uninitialized default value, triggers error when used.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>Left to right.</summary>
+        LeftToRight,
+
+        /// <summary>
+        /// Right to left (including vertical writing systems,
+        /// such as Chinese, Japanese, and Korean).
+        /// </summary>
+        RightToLeft,
+    };
+}

--- a/src/vanillapdf.net/PdfSemantics/PdfViewerPreferences.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfViewerPreferences.cs
@@ -1,0 +1,320 @@
+using System;
+using vanillapdf.net.Interop;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+using vanillapdf.net.Utils;
+
+namespace vanillapdf.net.PdfSemantics
+{
+    /// <summary>
+    /// Controls the way the document shall be presented on the
+    /// screen or in print. Retrieved via <see cref="PdfCatalog.GetViewerPreferences"/>.
+    /// </summary>
+    /// <remarks>
+    /// Each entry is optional. A property returns <c>null</c> when the corresponding
+    /// entry is absent from the viewer preferences dictionary.
+    /// </remarks>
+    public class PdfViewerPreferences : IDisposable
+    {
+        internal PdfViewerPreferencesSafeHandle Handle { get; }
+
+        internal PdfViewerPreferences(PdfViewerPreferencesSafeHandle handle)
+        {
+            Handle = handle;
+        }
+
+        /// <summary>
+        /// Whether to hide the conforming reader's tool bars when the document is active.
+        /// </summary>
+        public PdfBooleanObject HideToolbar => GetHideToolbar();
+
+        /// <summary>
+        /// Whether to hide the conforming reader's menu bar when the document is active.
+        /// </summary>
+        public PdfBooleanObject HideMenubar => GetHideMenubar();
+
+        /// <summary>
+        /// Whether to hide user interface elements in the document's window
+        /// (such as scroll bars and navigation controls), leaving only the
+        /// document's contents displayed.
+        /// </summary>
+        public PdfBooleanObject HideWindowUI => GetHideWindowUI();
+
+        /// <summary>
+        /// Whether to resize the document's window to fit the size of the first displayed page.
+        /// </summary>
+        public PdfBooleanObject FitWindow => GetFitWindow();
+
+        /// <summary>
+        /// Whether to position the document's window in the center of the screen.
+        /// </summary>
+        public PdfBooleanObject CenterWindow => GetCenterWindow();
+
+        /// <summary>
+        /// Whether the window's title bar should display the document title taken
+        /// from the Title entry of the document information dictionary. If false, the
+        /// title bar should instead display the name of the PDF file.
+        /// </summary>
+        public PdfBooleanObject DisplayDocTitle => GetDisplayDocTitle();
+
+        /// <summary>
+        /// The document's page mode, specifying how to display the document
+        /// on exiting full-screen mode.
+        /// </summary>
+        public PdfNonFullScreenPageMode? NonFullScreenPageMode => GetNonFullScreenPageMode();
+
+        /// <summary>
+        /// The predominant reading order for text.
+        /// </summary>
+        public PdfReadingOrder? Direction => GetDirection();
+
+        /// <summary>
+        /// The name of the page boundary representing the area of a page that shall
+        /// be displayed when viewing the document on the screen.
+        /// </summary>
+        public PdfNameObject ViewArea => GetViewArea();
+
+        /// <summary>
+        /// The name of the page boundary to which the contents of a page shall be
+        /// clipped when viewing the document on the screen.
+        /// </summary>
+        public PdfNameObject ViewClip => GetViewClip();
+
+        /// <summary>
+        /// The name of the page boundary representing the area of a page that shall
+        /// be rendered when printing the document.
+        /// </summary>
+        public PdfNameObject PrintArea => GetPrintArea();
+
+        /// <summary>
+        /// The name of the page boundary to which the contents of a page shall be
+        /// clipped when printing the document.
+        /// </summary>
+        public PdfNameObject PrintClip => GetPrintClip();
+
+        /// <summary>
+        /// The page scaling option that shall be selected when a print dialog
+        /// is displayed for this document.
+        /// </summary>
+        public PdfPrintScaling? PrintScaling => GetPrintScaling();
+
+        /// <summary>
+        /// The paper handling option that shall be used when printing the file
+        /// from the print dialog.
+        /// </summary>
+        public PdfDuplex? Duplex => GetDuplex();
+
+        /// <summary>
+        /// Whether the PDF page size shall be used to select the input paper tray.
+        /// </summary>
+        public PdfBooleanObject PickTrayByPDFSize => GetPickTrayByPDFSize();
+
+        /// <summary>
+        /// The number of copies that shall be printed when the print dialog
+        /// is opened for this file.
+        /// </summary>
+        public PdfIntegerObject NumCopies => GetNumCopies();
+
+        #region Private Methods
+
+        private PdfBooleanObject GetHideToolbar()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetHideToolbar(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfBooleanObject GetHideMenubar()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetHideMenubar(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfBooleanObject GetHideWindowUI()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetHideWindowUI(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfBooleanObject GetFitWindow()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetFitWindow(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfBooleanObject GetCenterWindow()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetCenterWindow(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfBooleanObject GetDisplayDocTitle()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetDisplayDocTitle(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfNonFullScreenPageMode? GetNonFullScreenPageMode()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetNonFullScreenPageMode(Handle, out int data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return EnumUtil<PdfNonFullScreenPageMode>.CheckedCast(data);
+        }
+
+        private PdfReadingOrder? GetDirection()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetDirection(Handle, out int data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return EnumUtil<PdfReadingOrder>.CheckedCast(data);
+        }
+
+        private PdfNameObject GetViewArea()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetViewArea(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfNameObject(data);
+        }
+
+        private PdfNameObject GetViewClip()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetViewClip(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfNameObject(data);
+        }
+
+        private PdfNameObject GetPrintArea()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetPrintArea(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfNameObject(data);
+        }
+
+        private PdfNameObject GetPrintClip()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetPrintClip(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfNameObject(data);
+        }
+
+        private PdfPrintScaling? GetPrintScaling()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetPrintScaling(Handle, out int data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return EnumUtil<PdfPrintScaling>.CheckedCast(data);
+        }
+
+        private PdfDuplex? GetDuplex()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetDuplex(Handle, out int data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return EnumUtil<PdfDuplex>.CheckedCast(data);
+        }
+
+        private PdfBooleanObject GetPickTrayByPDFSize()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetPickTrayByPDFSize(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfBooleanObject(data);
+        }
+
+        private PdfIntegerObject GetNumCopies()
+        {
+            UInt32 result = NativeMethods.ViewerPreferences_GetNumCopies(Handle, out var data);
+            if (result == PdfReturnValues.ERROR_OBJECT_MISSING) {
+                return null;
+            }
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+            return new PdfIntegerObject(data);
+        }
+
+        #endregion
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Handle?.Dispose();
+        }
+    }
+}

--- a/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
+++ b/src/vanillapdf.net/Utils/SafeHandles/PdfSemanticsSafeHandles.cs
@@ -807,4 +807,9 @@ namespace vanillapdf.net.Utils
     {
         protected override bool ReleaseHandle() => NativeMethods.ByteRangeCollection_Release(handle) == PdfReturnValues.ERROR_SUCCESS;
     }
+
+    internal sealed class PdfViewerPreferencesSafeHandle : PdfSafeHandle
+    {
+        protected override bool ReleaseHandle() => NativeMethods.ViewerPreferences_Release(handle) == PdfReturnValues.ERROR_SUCCESS;
+    }
 }


### PR DESCRIPTION
## Summary

Binds two read-only `Catalog` accessors from the native library (2.3.0-rc.1), surfacing viewer/print presentation hints to managed code. Purely additive and low-risk, targeted for the upcoming 2.3.0 release.

- **`Catalog.GetViewerPreferences()`** → new `PdfViewerPreferences` wrapper exposing 16 getters: hide toolbar/menubar/window UI, fit/center window, display doc title, non-full-screen page mode, reading direction, view/print area & clip, print scaling, duplex, pick tray by PDF size, and number of copies. Absent dictionary entries return `null`, matching the native optional-entry contract.
- **`Catalog.GetPageLayout()`** → new `PdfPageLayoutType` enum (single page, one/two column, two page left/right).
- New enums: `PdfPageLayoutType`, `PdfNonFullScreenPageMode`, `PdfReadingOrder`, `PdfPrintScaling`, `PdfDuplex`.
- P/Invoke declarations added to both the `DllImport` (.NET Standard 2.0) and `LibraryImport` (.NET 7+) interop partials, plus `PdfViewerPreferencesSafeHandle`.

### Scope note
`ViewerPreferences_GetPrintPageRange` is intentionally omitted — it returns the still-unbound `PageRange` type, which would pull in `PageRange`/`PageSubRange` and expand the surface beyond what's appropriate this close to release.

## Test plan
- Main library builds clean on both target frameworks (netstandard2.0 + net8.0).
- 7 new tests using real fixtures: `PageLayout=OneColumn` (`19005-1_FAQ.PDF`), `CenterWindow=true` plus absent-entry nulls (`20131231…pdf`), and an empty ViewerPreferences dictionary (`Granizo.pdf`).
- Full suite: **250/250 pass**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)