### PR TITLE
Release: publish the draft by id, split publish into two gated jobs

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -6,6 +6,10 @@ name: Create GitHub Release
 
 on:
   workflow_call:
+    outputs:
+      release_id:
+        description: "Numeric id of the draft release (drafts cannot be addressed by tag - the tag does not exist until publish)"
+        value: ${{ jobs.github-release.outputs.release_id }}
     inputs:
       tag:
         required: true
@@ -53,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to create a release
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
 
     steps:
       - name: Checkout code
@@ -61,35 +67,50 @@ jobs:
           fetch-depth: 0
 
       - name: Create draft release
+        id: create
         env:
           TAG: ${{ inputs.tag }}
           PRERELEASE: ${{ inputs.prerelease }}
           LATEST: ${{ inputs.latest }}
           TARGET: ${{ inputs.target }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           echo "Creating draft release for tag: $TAG"
           if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG already exists. Skipping."
-            exit 0
+            echo "Release $TAG already exists. Skipping create."
+          else
+            # The tag must NOT exist yet: publishing this draft is what creates the
+            # tag (at TARGET) and binds the release to it. Pre-creating the tag
+            # would leave the published release stuck on its untagged placeholder.
+            FLAGS=()
+            if [ "$PRERELEASE" = "true" ]; then
+              FLAGS+=(--prerelease)
+            fi
+            if [ "$LATEST" = "false" ]; then
+              FLAGS+=(--latest=false)
+            fi
+            if [ -n "$TARGET" ]; then
+              FLAGS+=(--target "$TARGET")
+            fi
+
+            gh release create "$TAG" \
+              --title "vanillapdf $TAG" \
+              --generate-notes \
+              --draft \
+              "${FLAGS[@]}"
           fi
 
-          # The tag must NOT exist yet: publishing this draft is what creates the
-          # tag (at TARGET) and binds the release to it. Pre-creating the tag
-          # would leave the published release stuck on its untagged placeholder.
-          FLAGS=()
-          if [ "$PRERELEASE" = "true" ]; then
-            FLAGS+=(--prerelease)
+          # Expose the numeric release id: later jobs must address the draft by
+          # id, not by tag. The tag does not exist as a ref until the draft is
+          # published, and an API edit to the draft body that omits tag_name
+          # resets it, after which tag-based lookup fails with "release not
+          # found".
+          RELEASE_ID=$(gh api "repos/${GH_REPO}/releases" \
+            --jq ".[] | select(.tag_name == \"$TAG\") | .id" | head -n 1)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "::error::Could not resolve release id for $TAG"
+            exit 1
           fi
-          if [ "$LATEST" = "false" ]; then
-            FLAGS+=(--latest=false)
-          fi
-          if [ -n "$TARGET" ]; then
-            FLAGS+=(--target "$TARGET")
-          fi
-
-          gh release create "$TAG" \
-            --title "vanillapdf $TAG" \
-            --generate-notes \
-            --draft \
-            "${FLAGS[@]}"
+          echo "Resolved release id: $RELEASE_ID"
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,35 +206,52 @@ jobs:
       target: ${{ github.sha }}
     secrets: inherit
 
-  # Single production gate. The `production` environment's required reviewer and
-  # wait timer pause the run here, giving a human the window to edit the draft
-  # release body before approving. On approval this one job does the whole
-  # publish: publishing the draft creates the tag (via BOT_TOKEN, so it passes
-  # the tag-protection ruleset), then the package is pushed to NuGet.org via
-  # OIDC trusted publishing. Keeping it a single environment job means exactly
-  # one approval, not one per publish step.
-  publish:
+  # Production gate + publish. Both publish jobs depend only on
+  # create-draft-release and both reference the `production` environment, so
+  # they enter the waiting state together and one review approves them both -
+  # a single gate, during which a human can edit the draft release body. Being
+  # separate jobs, either can be re-run on its own if it fails (a re-run asks
+  # for approval again).
+  #
+  # Publishing the draft creates the tag (via BOT_TOKEN, so it passes the
+  # tag-protection ruleset). The draft is addressed by its numeric id, never by
+  # tag: the tag does not exist until this step, and an API edit to the draft
+  # body that omits tag_name resets it, so tag-based lookup can fail with
+  # "release not found". Re-asserting tag_name in the same PATCH that flips
+  # draft=false makes the publish immune to that quirk.
+  publish-release:
     runs-on: ubuntu-latest
     needs: [create-draft-release, prepare]
     if: needs.prepare.outputs.dry_run == 'false'
     environment: production
     permissions:
       contents: write  # create the tag by publishing the draft
-      id-token: write  # GitHub OIDC token for NuGet trusted publishing
     steps:
       - name: Publish draft release (creates the tag)
         env:
+          RELEASE_ID: ${{ needs.create-draft-release.outputs.release_id }}
           TAG: ${{ needs.prepare.outputs.tag }}
           IS_LATEST: ${{ needs.prepare.outputs.is_latest }}
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          LATEST_FLAG=""
-          if [ "$IS_LATEST" = "false" ]; then
-            LATEST_FLAG="--latest=false"
+          MAKE_LATEST=false
+          if [ "$IS_LATEST" = "true" ]; then
+            MAKE_LATEST=true
           fi
-          gh release edit "$TAG" --draft=false $LATEST_FLAG
+          gh api --method PATCH "repos/${GH_REPO}/releases/${RELEASE_ID}" \
+            -f tag_name="$TAG" \
+            -F draft=false \
+            -f make_latest="$MAKE_LATEST"
 
+  publish-nuget:
+    runs-on: ubuntu-latest
+    needs: [create-draft-release, prepare]
+    if: needs.prepare.outputs.dry_run == 'false'
+    environment: production
+    permissions:
+      id-token: write  # GitHub OIDC token for NuGet trusted publishing
+    steps:
       - name: Download NuGet packages
         uses: actions/download-artifact@v8
         with:

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -31,13 +31,19 @@ workflow owns tag creation end to end.
    as a **draft** — still without creating the tag.
 
 3. **Review.** A single `production` environment gate (wait timer + one required
-   reviewer) pauses the workflow. Review and edit the draft release body in the
-   GitHub UI, then approve.
+   reviewer) pauses the workflow. Review and edit the draft release body, then
+   approve. Editing in the GitHub UI is always safe; if editing via the API,
+   the publish step is immune to the draft `tag_name`-reset quirk (it addresses
+   the draft by id and re-asserts `tag_name`), but including `tag_name` in any
+   PATCH is still good hygiene.
 
-4. **Publish.** Approving runs the one publish job: it publishes the draft —
-   which is what actually **creates the tag** (at the commit the workflow ran on)
-   and binds the release to it — and then pushes the package to NuGet.org via
-   OIDC trusted publishing. One approval covers both steps.
+4. **Publish.** Both publish jobs wait on the same `production` environment and
+   pend together, so **one approval releases both**: `publish-release` publishes
+   the draft by its numeric id — which is what actually **creates the tag** (at
+   the commit the workflow ran on) and binds the release to it — while
+   `publish-nuget` pushes the package to NuGet.org via OIDC trusted publishing.
+   The jobs are independent, so a failed one can be re-run on its own (the
+   re-run asks for approval again).
 
 > Whether a tag counts as a pre-release is derived automatically from its suffix
 > (`-alpha.N`, `-beta.N`, `-rc.N`) by the `prepare` job in `release.yml`. Stable
@@ -74,7 +80,7 @@ a real release. The pre-release suffix is supplied only through the tag input
 | --- | --- | --- |
 | `release.yml` | `workflow_dispatch` (real releases) · `pull_request` (dry-run validation of workflow changes) | ✅ unless `dry_run: true` |
 | `build-nuget.yml` | called by `release.yml`; also on pushes/PRs that touch it | ❌ builds & tests only |
-| `github-release.yml` | called by `release.yml` | Creates the **draft** only; the tag is created when the draft is published |
+| `github-release.yml` | called by `release.yml` | Creates the **draft** only and outputs its numeric `release_id`; the tag is created when the draft is published |
 
 Notes:
 


### PR DESCRIPTION
## Summary

The v2.3.0-rc.1 release run ([failure](https://github.com/vanillapdf/vanillapdf.net/actions/runs/29246895478/job/86806661155)) died at the publish step with `release not found`. Root cause: the draft's body was edited via the API during the production gate, and a PATCH that omits `tag_name` **resets the draft's tag_name**, after which `gh release edit <tag>` cannot find the draft.

## Changes

- **`github-release.yml`**: after creating the draft, resolve its numeric id from the releases list and expose it as a `release_id` workflow output.
- **`release.yml`**: publish the draft by that id via `gh api --method PATCH`, re-asserting `tag_name` in the same call that flips `draft=false` — immune to the tag_name-reset quirk however the body gets edited.
- **`release.yml`**: split the single `publish` job into `publish-release` and `publish-nuget`. Both depend only on `create-draft-release` and both reference the `production` environment, so they pend together and **one review approves both**, while either can be re-run independently if it fails. `publish-nuget` keeps the `production` environment binding required by the nuget.org Trusted Publishing policy.
- **`RELEASE-GUIDE.md`**: updated review/publish steps accordingly.

## Notes

- The native repo's `publish-release` has the same latent tag-based lookup; it has only survived because drafts there are edited in the UI. A matching fix will be ported there separately.
- This PR triggers the release workflow's `pull_request` dry-run validation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)