### PR TITLE
Fix native handle leaks in derived semantic objects

### DIFF
--- a/src/vanillapdf.net/PdfSemantics/PdfAction.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfAction.cs
@@ -12,11 +12,11 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfAction : IDisposable
     {
-        internal PdfActionSafeHandle Handle { get; }
+        internal PdfActionSafeHandle ActionHandle { get; }
 
         internal PdfAction(PdfActionSafeHandle handle)
         {
-            Handle = handle;
+            ActionHandle = handle;
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Action_GetActionType(Handle, out Int32 data);
+                UInt32 result = NativeMethods.Action_GetActionType(ActionHandle, out Int32 data);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -54,7 +54,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public virtual void Dispose()
         {
-            Handle?.Dispose();
+            ActionHandle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfAnnotation.cs
@@ -13,11 +13,11 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfAnnotation : IDisposable
     {
-        internal PdfAnnotationSafeHandle Handle { get; }
+        internal PdfAnnotationSafeHandle AnnotationHandle { get; }
 
         internal PdfAnnotation(PdfAnnotationSafeHandle handle)
         {
-            Handle = handle;
+            AnnotationHandle = handle;
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <returns>Type of derived object on success, throws exception on failure</returns>
         public PdfAnnotationType GetAnnotationType()
         {
-            UInt32 result = NativeMethods.Annotation_GetAnnotationType(Handle, out Int32 data);
+            UInt32 result = NativeMethods.Annotation_GetAnnotationType(AnnotationHandle, out Int32 data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -41,7 +41,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Annotation_GetRect(Handle, out var data);
+                UInt32 result = NativeMethods.Annotation_GetRect(AnnotationHandle, out var data);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -49,7 +49,7 @@ namespace vanillapdf.net.PdfSemantics
             }
             set
             {
-                UInt32 result = NativeMethods.Annotation_SetRect(Handle, value.Handle);
+                UInt32 result = NativeMethods.Annotation_SetRect(AnnotationHandle, value.Handle);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -63,7 +63,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Annotation_GetContents(Handle, out var data);
+                UInt32 result = NativeMethods.Annotation_GetContents(AnnotationHandle, out var data);
                 if (result == PdfReturnValues.ERROR_OBJECT_MISSING) return null;
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
@@ -72,7 +72,7 @@ namespace vanillapdf.net.PdfSemantics
             }
             set
             {
-                UInt32 result = NativeMethods.Annotation_SetContents(Handle, value.Handle);
+                UInt32 result = NativeMethods.Annotation_SetContents(AnnotationHandle, value.Handle);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -86,7 +86,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Annotation_GetColor(Handle, out var data);
+                UInt32 result = NativeMethods.Annotation_GetColor(AnnotationHandle, out var data);
                 if (result == PdfReturnValues.ERROR_OBJECT_MISSING) return null;
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
@@ -95,7 +95,7 @@ namespace vanillapdf.net.PdfSemantics
             }
             set
             {
-                UInt32 result = NativeMethods.Annotation_SetColor(Handle, value.Handle);
+                UInt32 result = NativeMethods.Annotation_SetColor(AnnotationHandle, value.Handle);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -109,7 +109,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Annotation_GetFlags(Handle, out Int32 data);
+                UInt32 result = NativeMethods.Annotation_GetFlags(AnnotationHandle, out Int32 data);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -117,7 +117,7 @@ namespace vanillapdf.net.PdfSemantics
             }
             set
             {
-                UInt32 result = NativeMethods.Annotation_SetFlags(Handle, (Int32)value);
+                UInt32 result = NativeMethods.Annotation_SetFlags(AnnotationHandle, (Int32)value);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -127,7 +127,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public virtual void Dispose()
         {
-            Handle?.Dispose();
+            AnnotationHandle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDestination.cs
@@ -12,11 +12,11 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfDestination : IDisposable
     {
-        internal PdfDestinationSafeHandle Handle { get; }
+        internal PdfDestinationSafeHandle DestinationHandle { get; }
 
         internal PdfDestination(PdfDestinationSafeHandle handle)
         {
-            Handle = handle;
+            DestinationHandle = handle;
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Destination_GetDestinationType(Handle, out Int32 data);
+                UInt32 result = NativeMethods.Destination_GetDestinationType(DestinationHandle, out Int32 data);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -93,7 +93,7 @@ namespace vanillapdf.net.PdfSemantics
         {
             get
             {
-                UInt32 result = NativeMethods.Destination_GetPageNumber(Handle, out var data);
+                UInt32 result = NativeMethods.Destination_GetPageNumber(DestinationHandle, out var data);
                 if (result != PdfReturnValues.ERROR_SUCCESS) {
                     throw PdfErrors.GetLastErrorException();
                 }
@@ -103,9 +103,9 @@ namespace vanillapdf.net.PdfSemantics
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public virtual void Dispose()
         {
-            Handle?.Dispose();
+            DestinationHandle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfDestinationNameTree.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfDestinationNameTree.cs
@@ -94,7 +94,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="destination">The destination to insert.</param>
         public void Insert(PdfStringObject name, PdfDestination destination)
         {
-            UInt32 result = NativeMethods.DestinationNameTree_Insert(Handle, name.StringHandle, destination.Handle);
+            UInt32 result = NativeMethods.DestinationNameTree_Insert(Handle, name.StringHandle, destination.DestinationHandle);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxDestination.cs
@@ -9,7 +9,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitBoundingBoxDestination : PdfDestination
     {
-        internal new PdfFitBoundingBoxDestinationSafeHandle Handle { get; }
+        internal PdfFitBoundingBoxDestinationSafeHandle Handle { get; }
 
         internal PdfFitBoundingBoxDestination(PdfFitBoundingBoxDestinationSafeHandle handle) : base(handle)
         {
@@ -21,7 +21,14 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitBoundingBoxDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitBoundingBoxDestination(data.Handle);
+            return new PdfFitBoundingBoxDestination(data.DestinationHandle);
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxHorizontalDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxHorizontalDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitBoundingBoxHorizontalDestination : PdfDestination
     {
-        internal new PdfFitBoundingBoxHorizontalDestinationSafeHandle Handle { get; }
+        internal PdfFitBoundingBoxHorizontalDestinationSafeHandle Handle { get; }
 
         internal PdfFitBoundingBoxHorizontalDestination(PdfFitBoundingBoxHorizontalDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitBoundingBoxHorizontalDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitBoundingBoxHorizontalDestination(data.Handle);
+            return new PdfFitBoundingBoxHorizontalDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -43,6 +43,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxVerticalDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitBoundingBoxVerticalDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitBoundingBoxVerticalDestination : PdfDestination
     {
-        internal new PdfFitBoundingBoxVerticalDestinationSafeHandle Handle { get; }
+        internal PdfFitBoundingBoxVerticalDestinationSafeHandle Handle { get; }
 
         internal PdfFitBoundingBoxVerticalDestination(PdfFitBoundingBoxVerticalDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitBoundingBoxVerticalDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitBoundingBoxVerticalDestination(data.Handle);
+            return new PdfFitBoundingBoxVerticalDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -43,6 +43,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitDestination.cs
@@ -9,7 +9,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitDestination : PdfDestination
     {
-        internal new PdfFitDestinationSafeHandle Handle { get; }
+        internal PdfFitDestinationSafeHandle Handle { get; }
 
         internal PdfFitDestination(PdfFitDestinationSafeHandle handle) : base(handle)
         {
@@ -21,7 +21,14 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitDestination(data.Handle);
+            return new PdfFitDestination(data.DestinationHandle);
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitHorizontalDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitHorizontalDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitHorizontalDestination : PdfDestination
     {
-        internal new PdfFitHorizontalDestinationSafeHandle Handle { get; }
+        internal PdfFitHorizontalDestinationSafeHandle Handle { get; }
 
         internal PdfFitHorizontalDestination(PdfFitHorizontalDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitHorizontalDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitHorizontalDestination(data.Handle);
+            return new PdfFitHorizontalDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -43,6 +43,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitRectangleDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitRectangleDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitRectangleDestination : PdfDestination
     {
-        internal new PdfFitRectangleDestinationSafeHandle Handle { get; }
+        internal PdfFitRectangleDestinationSafeHandle Handle { get; }
 
         internal PdfFitRectangleDestination(PdfFitRectangleDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitRectangleDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitRectangleDestination(data.Handle);
+            return new PdfFitRectangleDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -94,6 +94,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFitVerticalDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFitVerticalDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFitVerticalDestination : PdfDestination
     {
-        internal new PdfFitVerticalDestinationSafeHandle Handle { get; }
+        internal PdfFitVerticalDestinationSafeHandle Handle { get; }
 
         internal PdfFitVerticalDestination(PdfFitVerticalDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfFitVerticalDestination FromDestination(PdfDestination data)
         {
-            return new PdfFitVerticalDestination(data.Handle);
+            return new PdfFitVerticalDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -43,6 +43,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }

--- a/src/vanillapdf.net/PdfSemantics/PdfFreeTextAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfFreeTextAnnotation.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfFreeTextAnnotation : PdfAnnotation
     {
-        internal new PdfFreeTextAnnotationSafeHandle Handle { get; }
+        internal PdfFreeTextAnnotationSafeHandle Handle { get; }
 
         internal PdfFreeTextAnnotation(PdfFreeTextAnnotationSafeHandle handle) : base(handle)
         {
@@ -41,7 +41,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfFreeTextAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.FreeTextAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.FreeTextAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -143,6 +143,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfGoToAction.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfGoToAction.cs
@@ -10,7 +10,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfGoToAction : PdfAction
     {
-        internal new PdfGoToActionSafeHandle Handle { get; }
+        internal PdfGoToActionSafeHandle Handle { get; }
 
         internal PdfGoToAction(PdfGoToActionSafeHandle handle) : base(handle)
         {
@@ -22,7 +22,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfGoToAction FromAction(PdfAction action)
         {
-            return new PdfGoToAction(action.Handle);
+            return new PdfGoToAction(action.ActionHandle);
         }
 
         /// <summary>
@@ -44,6 +44,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfGoToRemoteAction.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfGoToRemoteAction.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfGoToRemoteAction : PdfAction
     {
-        internal new PdfGoToRemoteActionSafeHandle Handle { get; }
+        internal PdfGoToRemoteActionSafeHandle Handle { get; }
 
         internal PdfGoToRemoteAction(PdfGoToRemoteActionSafeHandle handle) : base(handle)
         {
@@ -24,7 +24,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfGoToRemoteAction FromAction(PdfAction action)
         {
-            return new PdfGoToRemoteAction(action.Handle);
+            return new PdfGoToRemoteAction(action.ActionHandle);
         }
 
         /// <summary>
@@ -64,6 +64,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfHighlightAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfHighlightAnnotation.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfHighlightAnnotation : PdfAnnotation
     {
-        internal new PdfHighlightAnnotationSafeHandle Handle { get; }
+        internal PdfHighlightAnnotationSafeHandle Handle { get; }
 
         internal PdfHighlightAnnotation(PdfHighlightAnnotationSafeHandle handle) : base(handle)
         {
@@ -50,7 +50,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfHighlightAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.HighlightAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.HighlightAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -152,6 +152,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfInkAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfInkAnnotation.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfInkAnnotation : PdfAnnotation
     {
-        internal new PdfInkAnnotationSafeHandle Handle { get; }
+        internal PdfInkAnnotationSafeHandle Handle { get; }
 
         internal PdfInkAnnotation(PdfInkAnnotationSafeHandle handle) : base(handle)
         {
@@ -51,7 +51,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfInkAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.InkAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.InkAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -153,6 +153,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfLinkAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfLinkAnnotation.cs
@@ -11,7 +11,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfLinkAnnotation : PdfAnnotation
     {
-        internal new PdfLinkAnnotationSafeHandle Handle { get; }
+        internal PdfLinkAnnotationSafeHandle Handle { get; }
 
         internal PdfLinkAnnotation(PdfLinkAnnotationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <returns>A link annotation instance.</returns>
         public static PdfLinkAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.LinkAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.LinkAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -71,6 +71,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfNamedAction.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfNamedAction.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfNamedAction : PdfAction
     {
-        internal new PdfNamedActionSafeHandle Handle { get; }
+        internal PdfNamedActionSafeHandle Handle { get; }
 
         internal PdfNamedAction(PdfNamedActionSafeHandle handle) : base(handle)
         {
@@ -24,7 +24,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfNamedAction FromAction(PdfAction action)
         {
-            return new PdfNamedAction(action.Handle);
+            return new PdfNamedAction(action.ActionHandle);
         }
 
         /// <summary>
@@ -46,6 +46,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfPageAnnotations.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfPageAnnotations.cs
@@ -65,7 +65,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The annotation to append.</param>
         public void Append(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.PageAnnotations_Append(Handle, annotation.Handle);
+            UInt32 result = NativeMethods.PageAnnotations_Append(Handle, annotation.AnnotationHandle);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }

--- a/src/vanillapdf.net/PdfSemantics/PdfSquigglyAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfSquigglyAnnotation.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfSquigglyAnnotation : PdfAnnotation
     {
-        internal new PdfSquigglyAnnotationSafeHandle Handle { get; }
+        internal PdfSquigglyAnnotationSafeHandle Handle { get; }
 
         internal PdfSquigglyAnnotation(PdfSquigglyAnnotationSafeHandle handle) : base(handle)
         {
@@ -50,7 +50,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfSquigglyAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.SquigglyAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.SquigglyAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -152,6 +152,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfStrikeOutAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfStrikeOutAnnotation.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfStrikeOutAnnotation : PdfAnnotation
     {
-        internal new PdfStrikeOutAnnotationSafeHandle Handle { get; }
+        internal PdfStrikeOutAnnotationSafeHandle Handle { get; }
 
         internal PdfStrikeOutAnnotation(PdfStrikeOutAnnotationSafeHandle handle) : base(handle)
         {
@@ -50,7 +50,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfStrikeOutAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.StrikeOutAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.StrikeOutAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -152,6 +152,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfTextAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfTextAnnotation.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfTextAnnotation : PdfAnnotation
     {
-        internal new PdfTextAnnotationSafeHandle Handle { get; }
+        internal PdfTextAnnotationSafeHandle Handle { get; }
 
         internal PdfTextAnnotation(PdfTextAnnotationSafeHandle handle) : base(handle)
         {
@@ -53,7 +53,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfTextAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.TextAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.TextAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -132,6 +132,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfURIAction.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfURIAction.cs
@@ -11,7 +11,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfURIAction : PdfAction
     {
-        internal new PdfURIActionSafeHandle Handle { get; }
+        internal PdfURIActionSafeHandle Handle { get; }
 
         internal PdfURIAction(PdfURIActionSafeHandle handle) : base(handle)
         {
@@ -23,7 +23,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfURIAction FromAction(PdfAction action)
         {
-            return new PdfURIAction(action.Handle);
+            return new PdfURIAction(action.ActionHandle);
         }
 
         /// <summary>
@@ -45,6 +45,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfUnderlineAnnotation.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfUnderlineAnnotation.cs
@@ -12,7 +12,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfUnderlineAnnotation : PdfAnnotation
     {
-        internal new PdfUnderlineAnnotationSafeHandle Handle { get; }
+        internal PdfUnderlineAnnotationSafeHandle Handle { get; }
 
         internal PdfUnderlineAnnotation(PdfUnderlineAnnotationSafeHandle handle) : base(handle)
         {
@@ -50,7 +50,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <param name="annotation">The base annotation to convert.</param>
         public static PdfUnderlineAnnotation FromAnnotation(PdfAnnotation annotation)
         {
-            UInt32 result = NativeMethods.UnderlineAnnotation_FromBaseAnnotation(annotation.Handle, out var data);
+            UInt32 result = NativeMethods.UnderlineAnnotation_FromBaseAnnotation(annotation.AnnotationHandle, out var data);
             if (result != PdfReturnValues.ERROR_SUCCESS) {
                 throw PdfErrors.GetLastErrorException();
             }
@@ -152,6 +152,7 @@ namespace vanillapdf.net.PdfSemantics
         /// <inheritdoc/>
         public override void Dispose()
         {
+            base.Dispose();
             Handle?.Dispose();
         }
     }

--- a/src/vanillapdf.net/PdfSemantics/PdfXYZDestination.cs
+++ b/src/vanillapdf.net/PdfSemantics/PdfXYZDestination.cs
@@ -13,7 +13,7 @@ namespace vanillapdf.net.PdfSemantics
     /// </summary>
     public class PdfXYZDestination : PdfDestination
     {
-        internal new PdfXYZDestinationSafeHandle Handle { get; }
+        internal PdfXYZDestinationSafeHandle Handle { get; }
 
         internal PdfXYZDestination(PdfXYZDestinationSafeHandle handle) : base(handle)
         {
@@ -25,7 +25,7 @@ namespace vanillapdf.net.PdfSemantics
         /// </summary>
         public static PdfXYZDestination FromDestination(PdfDestination data)
         {
-            return new PdfXYZDestination(data.Handle);
+            return new PdfXYZDestination(data.DestinationHandle);
         }
 
         /// <summary>
@@ -77,6 +77,13 @@ namespace vanillapdf.net.PdfSemantics
 
                 return new PdfObject(data);
             }
+        }
+
+        /// <inheritdoc/>
+        public override void Dispose()
+        {
+            base.Dispose();
+            Handle?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary

Derived semantic objects (annotations, actions, destinations) own **two** native handles: their typed handle and a separate base handle created by the implicit safe-handle conversion (`*_ToBase*`) in the base constructor. Disposal only ever released one of them:

- **12 annotation/action subclasses** (`PdfLinkAnnotation`, `PdfTextAnnotation`, `PdfGoToAction`, `PdfURIAction`, ...) overrode `Dispose` without calling `base.Dispose()`, leaking the base handle.
- **8 destination subclasses** (`PdfXYZDestination`, `PdfFit*Destination`) had no `Dispose` override at all because `PdfDestination.Dispose` was not `virtual`, leaking the typed handle.

## Changes

- Make `PdfDestination.Dispose` virtual and dispose both handles in every subclass (`base.Dispose()` + `Handle?.Dispose()`, matching the `PdfArrayObject` convention).
- Rename the base handle properties to `AnnotationHandle`, `ActionHandle`, and `DestinationHandle` (matching `PdfObject.ObjectHandle`) so subclasses no longer shadow `Handle` with `new`.
- Update call sites in `PdfPageAnnotations`, `PdfDestinationNameTree`, and the `FromAnnotation`/`FromAction`/`FromDestination` factories.

## Testing

- Full solution builds with zero compiler warnings.
- Full net8.0 test suite via vstest: 228/228 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)