### PR TITLE
Correct the documented object model and document release-body drafting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,14 @@ The library wraps a native C++17 library (`vanillapdf` NuGet package) using P/In
 
 - **`Interop/NativeMethods.*.cs`**: Centralized P/Invoke declarations using `DllImport` (for .NET Standard 2.0) and `LibraryImport` (for .NET 7+). The library is AOT-compatible on modern .NET.
 - **`Utils/SafeHandles/`**: SafeHandle wrappers for native pointers, ensuring proper cleanup.
-- **`Utils/LibraryInstance.cs`**: Diagnostics for tracking active SafeHandle and PdfUnknown object counts.
+- **`Utils/ObjectDiagnostics.cs`**: Native-backed counters for live/peak/total object counts.
+- **`Utils/LibraryInstance.cs`**: Library-level diagnostics, including the active SafeHandle count.
 
 ### Object Hierarchy
 
-All managed objects inherit from `PdfUnknown` (in `PdfUtils/`), which implements COM-style reference counting (`AddRef`/`Release`) and `IDisposable`. Objects must be disposed to release native resources.
+Managed objects are standalone classes that implement `IDisposable` and hold an internal `PdfXxxSafeHandle`. There is no common base class: `Dispose()` disposes the handle, and the SafeHandle's `ReleaseHandle` calls the native release function. Every object handed back by the native layer owns a handle and must be disposed to free it.
+
+Reference counting lives in the native library, not in managed code — there is no managed `PdfUnknown`/`AddRef`/`Release` (removed in #69). A derived object obtained from a getter (e.g. `catalog.GetPages()`) owns its own handle and must be disposed independently of its parent.
 
 ### Namespace Organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,8 +98,12 @@ Match the surrounding code. The house style is:
 - P/Invoke declarations are centralized in `Interop/NativeMethods.*.cs`. Use
   `DllImport` for the .NET Standard 2.0 target and `LibraryImport` for .NET 7+.
 - Native handles are wrapped in `SafeHandle` types under `Utils/SafeHandles/`.
-- All managed objects inherit from `PdfUnknown` and are `IDisposable`; every
-  native resource must be released via disposal.
+- Managed objects are `IDisposable` wrappers around a `SafeHandle`; there is no
+  common base class and no managed reference counting. `Dispose()` disposes the
+  handle, whose `ReleaseHandle` calls the native release function.
+- Any object returned across the interop boundary owns a handle. A wrapper that
+  hands out derived objects must let the caller dispose them — dropping a handle
+  on the floor leaks native memory.
 
 ## Submitting a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The library is organized into layers that mirror the native SDK:
 | `vanillapdf.net.PdfContents` | Content-stream parsing: operators, text and font operations, inline images. |
 | `vanillapdf.net.PdfUtils` | Streams, buffers, signing keys, certificate stores, logging. |
 
-All managed objects inherit from `PdfUnknown`, which implements COM-style reference counting over the native handles and is exposed to you as `IDisposable`.
+Every object the library hands you is `IDisposable` and owns a native handle, so dispose it when you are done — a `using` declaration is the easiest way. Objects returned from a getter (a page from a page tree, a catalog from a document) own their own handle and must each be disposed; disposing the parent does not dispose them.
 
 ---
 

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -31,7 +31,8 @@ workflow owns tag creation end to end.
    as a **draft** — still without creating the tag.
 
 3. **Review.** A single `production` environment gate (wait timer + one required
-   reviewer) pauses the workflow. Review and edit the draft release body, then
+   reviewer) pauses the workflow. Rewrite the draft release body — see
+   [Writing the Release Body](#️-writing-the-release-body) — then
    approve. Editing in the GitHub UI is always safe; if editing via the API,
    the publish step is immune to the draft `tag_name`-reset quirk (it addresses
    the draft by id and re-asserts `tag_name`), but including `tag_name` in any
@@ -49,6 +50,46 @@ workflow owns tag creation end to end.
 > (`-alpha.N`, `-beta.N`, `-rc.N`) by the `prepare` job in `release.yml`. Stable
 > tags (`vX.Y.Z` with no suffix) are additionally evaluated for whether they are
 > the newest version, which drives the GitHub "Latest" release flag.
+
+---
+
+## ✍️ Writing the Release Body
+
+`github-release.yml` creates the draft with `--generate-notes`, which produces a
+flat list of merged pull requests. That list is a starting point, not the
+release body: rewrite it during the review gate.
+
+**Scope depends on the kind of release.**
+
+| Release | Changelog base | Content |
+| --- | --- | --- |
+| Pre-release (`-alpha.N`, `-beta.N`, `-rc.N`) | the **previous pre-release** of the same version | Incremental — only what changed since then |
+| Stable (`vX.Y.Z`) | the **previous stable release** | Cumulative — the whole story since the last stable |
+
+The reasoning: a pre-release is read by whoever ran the previous pre-release, so
+repeating the full list tells them nothing new. A stable release is the first
+thing a user on the last stable version reads, so it has to stand alone — even
+though most of its content already appeared in the pre-release notes.
+
+**Structure.** Group the changes under headings rather than shipping a flat list,
+in descending order of what a consumer needs to know:
+
+1. **Breaking changes** — first, always, when present. Say what breaks and what
+   to do about it.
+2. **Highlights** — the native engine version this release targets, and the new
+   public APIs.
+3. **Fixes** — user-visible bugs that were fixed.
+4. **Internals** — refactors, CI, docs. Anything with no API impact. Mark it as
+   such, so nobody mistakes a cleanup for a behavior change.
+
+Close with the `**Full Changelog**` compare link against the base from the table
+above. On a pre-release, it is worth adding a second link comparing against the
+last stable, for readers arriving from there.
+
+**Only describe a change you have verified.** A PR title is not a description:
+check the diff before writing the line. An internal refactor described as a
+behavior change (or vice versa) sends people hunting for migrations that do not
+exist.
 
 ---
 

--- a/src/vanillapdf.net/Utils/LibraryInstance.cs
+++ b/src/vanillapdf.net/Utils/LibraryInstance.cs
@@ -129,10 +129,12 @@ namespace vanillapdf.net.Utils
         }
 
         /// <summary>
-        /// Get number of active PdfUnknown objects.
-        /// Backed by native ObjectDiagnostics for backward compatibility.
+        /// Get number of active native objects.
+        /// Kept under its legacy name for backward compatibility; the managed
+        /// PdfUnknown type no longer exists, so this reports the native
+        /// ObjectDiagnostics count.
         /// </summary>
-        /// <returns>Number of active PdfUnknown objects</returns>
+        /// <returns>Number of active native objects</returns>
         [Obsolete("Use ObjectDiagnostics.GetActiveObjectCount() instead. This method will be removed in a future version.")]
         public static int GetUnknownCounter()
         {


### PR DESCRIPTION
## Object model

`CLAUDE.md`, `README.md` and `CONTRIBUTING.md` all still claimed:

> All managed objects inherit from `PdfUnknown`, which implements COM-style reference counting (`AddRef`/`Release`).

None of that has been true since #69 removed `PdfUnknown`. Managed objects are standalone `IDisposable` classes holding an internal `PdfXxxSafeHandle`; `Dispose()` disposes the handle, whose `ReleaseHandle` calls the native release function. Reference counting lives in the native library, and live-object counts now come from `ObjectDiagnostics`, not from a managed counter (`LibraryInstance.GetUnknownCounter` survives only as an obsolete shim, whose XML comment is reworded here too).

The replacement wording also spells out the rule that #131 had to fix by hand: **an object returned from a getter owns its own handle and must be disposed independently of its parent.** That is the invariant a contributor needs and the old text actively obscured, since COM-style reference counting implies the opposite lifetime.

This matters ahead of 2.3.0: the stable release notes will call the `PdfUnknown` removal a breaking change, so the repo's own docs should not still be describing the removed model.

## Release body

`RELEASE-GUIDE.md` covered how the pipeline is triggered but said nothing about what to *write* in the draft, so the scope question got re-litigated at the gate. It now records the convention:

| Release | Changelog base | Content |
| --- | --- | --- |
| Pre-release (`-alpha.N`, `-beta.N`, `-rc.N`) | previous pre-release | Incremental |
| Stable (`vX.Y.Z`) | previous stable | Cumulative |

Plus the section order (breaking changes first; internals explicitly marked as no-API-impact), the compare-link footer, and the rule that a change is described from its diff rather than its PR title — the failure mode that nearly shipped an internal `PdfBuffer` cleanup (#124) in the rc.1 notes as a behavior change.

## Verification

Docs-only apart from one XML comment; `dotnet build -c Release` succeeds with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)