### PR TITLE
Publish the release with GITHUB_TOKEN and create the draft via REST

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -61,11 +61,6 @@ jobs:
       release_id: ${{ steps.create.outputs.release_id }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
       - name: Create draft release
         id: create
         env:
@@ -73,41 +68,56 @@ jobs:
           PRERELEASE: ${{ inputs.prerelease }}
           LATEST: ${{ inputs.latest }}
           TARGET: ${{ inputs.target }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          echo "Creating draft release for tag: $TAG"
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG already exists. Skipping create."
-          else
-            # The tag must NOT exist yet: publishing this draft is what creates the
-            # tag (at TARGET) and binds the release to it. Pre-creating the tag
-            # would leave the published release stuck on its untagged placeholder.
-            FLAGS=()
-            if [ "$PRERELEASE" = "true" ]; then
-              FLAGS+=(--prerelease)
-            fi
-            if [ "$LATEST" = "false" ]; then
-              FLAGS+=(--latest=false)
-            fi
-            if [ -n "$TARGET" ]; then
-              FLAGS+=(--target "$TARGET")
-            fi
-
-            gh release create "$TAG" \
-              --title "vanillapdf $TAG" \
-              --generate-notes \
-              --draft \
-              "${FLAGS[@]}"
-          fi
-
-          # Expose the numeric release id: later jobs must address the draft by
-          # id, not by tag. The tag does not exist as a ref until the draft is
-          # published, and an API edit to the draft body that omits tag_name
-          # resets it, after which tag-based lookup fails with "release not
-          # found".
+          # Reuse the draft from an earlier attempt rather than creating a second
+          # release for the same tag. A draft from a previous run has long since
+          # propagated, so looking it up in the list endpoint is safe here - which
+          # is NOT true of a draft created moments ago (see below).
           RELEASE_ID=$(gh api "repos/${GH_REPO}/releases" \
             --jq ".[] | select(.tag_name == \"$TAG\") | .id" | head -n 1)
+
+          if [ -n "$RELEASE_ID" ]; then
+            echo "Release $TAG already exists (id $RELEASE_ID). Skipping create."
+          else
+            echo "Creating draft release for tag: $TAG"
+
+            MAKE_LATEST=true
+            if [ "$LATEST" = "false" ]; then
+              MAKE_LATEST=false
+            fi
+
+            TARGET_ARG=()
+            if [ -n "$TARGET" ]; then
+              TARGET_ARG=(-f target_commitish="$TARGET")
+            fi
+
+            # Create through the REST API, not `gh release create`, because the
+            # POST response carries the new release's id. Re-reading the releases
+            # list to find the id of a release created milliseconds earlier is a
+            # race: that endpoint is eventually consistent and has returned a
+            # stale page, failing the run with "Could not resolve release id".
+            #
+            # The tag must NOT exist yet: publishing this draft is what creates
+            # the tag (at TARGET) and binds the release to it. Pre-creating the
+            # tag would leave the published release stuck on its untagged
+            # placeholder.
+            RELEASE_ID=$(gh api --method POST "repos/${GH_REPO}/releases" \
+              -f tag_name="$TAG" \
+              -f name="vanillapdf $TAG" \
+              -F draft=true \
+              -F prerelease="$PRERELEASE" \
+              -F generate_release_notes=true \
+              -f make_latest="$MAKE_LATEST" \
+              "${TARGET_ARG[@]}" \
+              --jq .id)
+          fi
+
+          # Later jobs address the draft by id, never by tag: the tag does not
+          # exist as a ref until the draft is published, and an API edit to the
+          # draft body that omits tag_name resets it, after which tag-based
+          # lookup fails with "release not found".
           if [ -z "$RELEASE_ID" ]; then
             echo "::error::Could not resolve release id for $TAG"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,12 +213,21 @@ jobs:
   # separate jobs, either can be re-run on its own if it fails (a re-run asks
   # for approval again).
   #
-  # Publishing the draft creates the tag (via BOT_TOKEN, so it passes the
-  # tag-protection ruleset). The draft is addressed by its numeric id, never by
-  # tag: the tag does not exist until this step, and an API edit to the draft
-  # body that omits tag_name resets it, so tag-based lookup can fail with
-  # "release not found". Re-asserting tag_name in the same PATCH that flips
-  # draft=false makes the publish immune to that quirk.
+  # Publishing the draft creates the tag. This uses GITHUB_TOKEN - the same
+  # token that created the draft. A separate BOT_TOKEN was used here before, on
+  # the belief that the tag-protection ruleset required it; it does not. That
+  # ruleset ("Protected release tags", refs/tags/v*.*.*) enforces only deletion,
+  # non_fast_forward and update, none of which restrict *creating* a tag, and it
+  # has no bypass actors, so a bot identity buys nothing. What it did cost was
+  # visibility: GitHub hides draft releases from tokens without push access and
+  # answers 404, so every publish attempt failed with "release not found" (gh)
+  # or a bare 404 (REST) against a draft that plainly existed.
+  #
+  # The draft is addressed by its numeric id, never by tag: the tag does not
+  # exist until this step, and an API edit to the draft body that omits tag_name
+  # resets it, so tag-based lookup can fail with "release not found".
+  # Re-asserting tag_name in the same PATCH that flips draft=false makes the
+  # publish immune to that quirk.
   publish-release:
     runs-on: ubuntu-latest
     needs: [create-draft-release, prepare]
@@ -232,7 +241,7 @@ jobs:
           RELEASE_ID: ${{ needs.create-draft-release.outputs.release_id }}
           TAG: ${{ needs.prepare.outputs.tag }}
           IS_LATEST: ${{ needs.prepare.outputs.is_latest }}
-          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           MAKE_LATEST=false

--- a/RELEASE-GUIDE.md
+++ b/RELEASE-GUIDE.md
@@ -87,8 +87,11 @@ Notes:
 - `release.yml` has **no** `push: tags:` trigger. On `pull_request` it runs the
   build/verify path with a synthetic tag derived from `<VersionPrefix>`, and is
   always a dry run.
-- Publishing the draft uses `BOT_TOKEN` so the new tag is accepted under the
-  repository's tag-protection ruleset.
+- Publishing the draft (and thereby creating the tag) uses the workflow's own
+  `GITHUB_TOKEN`. The `Protected release tags` ruleset restricts *deletion*,
+  *updating* and non-fast-forward moves of `v*.*.*` tags — not their creation —
+  so no bot identity is needed. A token without push access cannot even see a
+  draft release: GitHub answers `404`, not `403`.
 - The `staging` and `production` GitHub environments provide the human approval
   gate and scope the publishing credentials.
 


### PR DESCRIPTION
Two failures hit the v2.3.0-rc.1 release, both in the publish path. The package reached NuGet.org; the GitHub release could not be published.

## 1. `publish-release` could not see its own draft (the 404)

The job ran as `BOT_TOKEN`, which lacks push access to this repo — and GitHub hides draft releases from such tokens behind a **404**, not a 403. The same root cause produced both failures we saw:

| Attempt | Call | Error |
| --- | --- | --- |
| [run 29246895478](https://github.com/vanillapdf/vanillapdf.net/actions/runs/29246895478) | `gh release edit "$TAG" --draft=false` | `release not found` |
| [run 29366895929](https://github.com/vanillapdf/vanillapdf.net/actions/runs/29366895929) | `PATCH /releases/354067650` (by id, per #130) | `gh: Not Found (HTTP 404)` |

Release `354067650` existed and was correct in both cases — a token with push access reads it fine.

**`BOT_TOKEN` was never needed.** It was introduced on the belief that the tag-protection ruleset required a bot identity to create the tag. It does not:

```
Protected release tags  (refs/tags/v*.*.*)
  rules:         deletion, non_fast_forward, update
  bypass_actors: []
```

None of those restrict *creating* a tag, and with no bypass actors `BOT_TOKEN` was granted nothing that the workflow's own `GITHUB_TOKEN` lacks. It only cost visibility. So `publish-release` now uses `GITHUB_TOKEN` — the token that created the draft, and can therefore see it. No workflow triggers on `push: tags` or `release:` events, so nothing is lost by the tag being created with `GITHUB_TOKEN`.

Note this also means #130's by-id change, while correct on its own merits, did not fix the failure it was written for.

## 2. The id lookup was racy ("Could not resolve release id")

`create-draft-release` created the draft with `gh release create`, then resolved its id by re-reading the releases **list**. That endpoint is eventually consistent, and ~240 ms after the create it returned a stale page with no such release — failing the run even though the draft was perfectly fine.

Creating through the REST API removes the lookup entirely: the `POST` response carries the id. The list lookup survives only as the re-run idempotency check, where the draft it looks for is minutes old and long since propagated.

Also drops the `actions/checkout` step from `github-release.yml` — a full-depth clone that nothing in the job used.

## Verification

Both workflow files parse (`yaml.safe_load`) and the embedded shell passes `bash -n`. `release.yml` runs its dry-run path on any PR touching these files, so CI here exercises the change end to end.