### PR TITLE
Bump vanillapdf native dependency to 2.3.0-rc.2

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.3.0-rc.1" />
+    <PackageReference Include="vanillapdf" Version="2.3.0-rc.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps the native `vanillapdf` package `2.3.0-rc.1` → `2.3.0-rc.2`.

Engine changes picked up ([native rc.2 notes](https://github.com/vanillapdf/vanillapdf/releases/tag/v2.3.0-rc.2)):

- **Encryption** — RC4 key truncated to *n* bytes for the rev-3 standard security handler, fixing decryption of 40-bit RC4 (rev 3) PDFs (native #439).
- **FlateDecode** — corrected PNG Average/Paeth predictor reconstruction, which previously corrupted decoded data for streams using those predictors (native #440).
- **Xref** — `XrefEntry_InUse` now reports used-vs-compressed from the entry type instead of an internal lazy-load flag that read `false` for every entry of a freshly opened file (native #447). No ABI change; existing tests still pass.

The new `FilterBase_DecodeParams` / `FlateDecodeFilter_DecodeParams` API (native #440) is **not** in this PR — it lands as a follow-up stacked on this branch, keeping the mechanical bump separate from new binding surface (as with rc.1's #122 → #123/#124).

## Verification

`dotnet restore` + `dotnet build -c Release` succeed with no warnings. Full NUnit suite: **251 passed, 0 failed** (net10.0) against rc.2.