### PR TITLE
Bump vanillapdf native dependency to 2.3.0-rc.3

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.3.0-rc.2" />
+    <PackageReference Include="vanillapdf" Version="2.3.0-rc.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Bumps the `vanillapdf` native dependency from `2.3.0-rc.2` to `2.3.0-rc.3`, picking up the rc.3 encryption-engine fixes:

- **AES-128** now emits `/V 4` with `/AESV2` instead of silently falling back to RC4 (native #453)
- Encryption of streams using **array-format filters** such as `/Filter [/FlateDecode]` is corrected so the output reopens cleanly (native #460, #462)
- The **AES-256** (V=5/R=6) hash-round off-by-one is fixed (native #457)

These are all internal engine fixes with no ABI or API change, so no new bindings are required.

## Verification

- Forced clean restore resolves `2.3.0-rc.3`
- Release build clean (5 projects, 0 warnings)
- All 210 tests pass against rc.3 (net8.0)

## Follow-up

The encryption *binding* round-trip path (`AddEncryption` → `Save` → reopen → `SetEncryptionPassword` → read) is currently untested in this repo. The rc.3 crypto fixes themselves are covered in the native repo; extended .NET-side interop coverage will follow in a **separate PR** rather than expanding this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)