### PR TITLE
Add in-memory encryption round-trip tests

### DIFF
--- a/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentEncryptionRoundTripTest.cs
+++ b/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentEncryptionRoundTripTest.cs
@@ -21,6 +21,8 @@ namespace vanillapdf.net.nunit.PdfSemantics
         private const string UserPassword = "user-secret";
         private const string OwnerPassword = "owner-secret";
 
+        private static readonly string SourceDocument = Path.Combine("Resources", "19005-1_FAQ.PDF");
+
         [TestCase(PdfEncryptionAlgorithmType.AES, 128)]
         [TestCase(PdfEncryptionAlgorithmType.AES, 256)]
         [TestCase(PdfEncryptionAlgorithmType.RC4, 128)]
@@ -28,7 +30,7 @@ namespace vanillapdf.net.nunit.PdfSemantics
             PdfEncryptionAlgorithmType algorithm, int keyLength)
         {
             using var stream = PdfInputOutputStream.CreateFromMemory();
-            EncryptToStream(stream, algorithm, keyLength);
+            EncryptToStream(SourceDocument, stream, algorithm, keyLength);
 
             using var file = PdfFile.OpenStream(stream, "encryptedStream");
             file.Initialize();
@@ -48,7 +50,7 @@ namespace vanillapdf.net.nunit.PdfSemantics
             PdfEncryptionAlgorithmType algorithm, int keyLength)
         {
             using var stream = PdfInputOutputStream.CreateFromMemory();
-            EncryptToStream(stream, algorithm, keyLength);
+            EncryptToStream(SourceDocument, stream, algorithm, keyLength);
 
             using var file = PdfFile.OpenStream(stream, "encryptedStream");
             file.Initialize();
@@ -67,7 +69,7 @@ namespace vanillapdf.net.nunit.PdfSemantics
             PdfEncryptionAlgorithmType algorithm, int keyLength)
         {
             using var stream = PdfInputOutputStream.CreateFromMemory();
-            EncryptToStream(stream, algorithm, keyLength);
+            EncryptToStream(SourceDocument, stream, algorithm, keyLength);
 
             using var file = PdfFile.OpenStream(stream, "encryptedStream");
             file.Initialize();
@@ -76,10 +78,8 @@ namespace vanillapdf.net.nunit.PdfSemantics
             ClassicAssert.IsFalse(file.SetEncryptionPassword("definitely-wrong-password"));
         }
 
-        private static void EncryptToStream(PdfInputOutputStream destinationStream, PdfEncryptionAlgorithmType algorithm, int keyLength)
+        private static void EncryptToStream(string source, PdfInputOutputStream destinationStream, PdfEncryptionAlgorithmType algorithm, int keyLength)
         {
-            string source = Path.Combine("Resources", "19005-1_FAQ.PDF");
-
             using var file = PdfFile.Open(source);
             file.Initialize();
             using var document = PdfDocument.OpenFile(file);

--- a/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentEncryptionRoundTripTest.cs
+++ b/src/vanillapdf.net.nunit/PdfSemantics/PdfDocumentEncryptionRoundTripTest.cs
@@ -1,0 +1,103 @@
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using vanillapdf.net.PdfSemantics;
+using vanillapdf.net.PdfSyntax;
+using vanillapdf.net.PdfUtils;
+
+namespace vanillapdf.net.nunit.PdfSemantics
+{
+    /// <summary>
+    /// Exercises the managed encryption binding path end to end, entirely in memory:
+    /// apply encryption settings, save to an in-memory stream, reopen, and decrypt.
+    /// This guards the interop wiring (password buffer marshaling, AddEncryption /
+    /// SaveFile / SetEncryptionPassword return handling and SafeHandle lifetime)
+    /// rather than the native crypto correctness, which is covered in the native library.
+    /// </summary>
+    [TestFixture]
+    public class PdfDocumentEncryptionRoundTripTest
+    {
+        private const string UserPassword = "user-secret";
+        private const string OwnerPassword = "owner-secret";
+
+        [TestCase(PdfEncryptionAlgorithmType.AES, 128)]
+        [TestCase(PdfEncryptionAlgorithmType.AES, 256)]
+        [TestCase(PdfEncryptionAlgorithmType.RC4, 128)]
+        public void EncryptedDocument_ReopensAsEncrypted_AndDecryptsWithUserPassword(
+            PdfEncryptionAlgorithmType algorithm, int keyLength)
+        {
+            using var stream = PdfInputOutputStream.CreateFromMemory();
+            EncryptToStream(stream, algorithm, keyLength);
+
+            using var file = PdfFile.OpenStream(stream, "encryptedStream");
+            file.Initialize();
+
+            ClassicAssert.IsTrue(file.Encrypted);
+            ClassicAssert.IsTrue(file.SetEncryptionPassword(UserPassword));
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+            ClassicAssert.IsNotNull(catalog);
+        }
+
+        [TestCase(PdfEncryptionAlgorithmType.AES, 128)]
+        [TestCase(PdfEncryptionAlgorithmType.AES, 256)]
+        [TestCase(PdfEncryptionAlgorithmType.RC4, 128)]
+        public void EncryptedDocument_DecryptsWithOwnerPassword(
+            PdfEncryptionAlgorithmType algorithm, int keyLength)
+        {
+            using var stream = PdfInputOutputStream.CreateFromMemory();
+            EncryptToStream(stream, algorithm, keyLength);
+
+            using var file = PdfFile.OpenStream(stream, "encryptedStream");
+            file.Initialize();
+
+            ClassicAssert.IsTrue(file.SetEncryptionPassword(OwnerPassword));
+
+            using var document = PdfDocument.OpenFile(file);
+            using var catalog = document.GetCatalog();
+            ClassicAssert.IsNotNull(catalog);
+        }
+
+        [TestCase(PdfEncryptionAlgorithmType.AES, 128)]
+        [TestCase(PdfEncryptionAlgorithmType.AES, 256)]
+        [TestCase(PdfEncryptionAlgorithmType.RC4, 128)]
+        public void EncryptedDocument_RejectsWrongPassword(
+            PdfEncryptionAlgorithmType algorithm, int keyLength)
+        {
+            using var stream = PdfInputOutputStream.CreateFromMemory();
+            EncryptToStream(stream, algorithm, keyLength);
+
+            using var file = PdfFile.OpenStream(stream, "encryptedStream");
+            file.Initialize();
+
+            ClassicAssert.IsTrue(file.Encrypted);
+            ClassicAssert.IsFalse(file.SetEncryptionPassword("definitely-wrong-password"));
+        }
+
+        private static void EncryptToStream(PdfInputOutputStream destinationStream, PdfEncryptionAlgorithmType algorithm, int keyLength)
+        {
+            string source = Path.Combine("Resources", "19005-1_FAQ.PDF");
+
+            using var file = PdfFile.Open(source);
+            file.Initialize();
+            using var document = PdfDocument.OpenFile(file);
+            using var destinationFile = PdfFile.CreateStream(destinationStream, "encryptedStream");
+
+            // The password buffers must stay alive until after the save, since the native
+            // settings hold onto them while the document is being written.
+            using var userPassword = PdfBuffer.CreateFromData(Encoding.ASCII.GetBytes(UserPassword));
+            using var ownerPassword = PdfBuffer.CreateFromData(Encoding.ASCII.GetBytes(OwnerPassword));
+
+            using var settings = PdfDocumentEncryptionSettings.Create();
+            settings.EncryptionAlgorithmType = algorithm;
+            settings.KeyLength = keyLength;
+            settings.UserPassword = userPassword;
+            settings.OwnerPassword = ownerPassword;
+
+            document.AddEncryption(settings);
+            document.SaveFile(destinationFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds managed-binding test coverage for the document **encryption** path, which previously had none beyond a `PdfDocumentEncryptionSettings.Create()` stability loop. This is the follow-up promised in #138.

The tests encrypt an existing document, save it to an in-memory `PdfInputOutputStream`, reopen it from that same stream, and decrypt — **no temp files touch disk** (mirrors the in-memory idiom already used in the signature tests).

## What it covers

Parameterized over `(AES, 128)`, `(AES, 256)` and `(RC4, 128)`, so the suite drives the rc.3-fixed engine paths (AES-128 `/V4 /AESV2` native #453, AES-256 R6 hash rounds native #457) as a side effect. The assertions deliberately target the **interop wiring, not the crypto math** (which is covered natively):

- Password `PdfBuffer` marshaling across P/Invoke
- `AddEncryption` / `SaveFile` / `SetEncryptionPassword` return-code handling and SafeHandle lifetime
- `PdfFile.Encrypted` on a reopened self-encrypted document

Each case verifies the document reopens as encrypted, decrypts with **both** the user and owner password, and **rejects** a wrong password. Confirmed empirically that `KeyLength` is expressed in **bits** (128/256).

## Verification

All 260 tests pass (251 prior + 9 new) on net9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)