### PR TITLE
Bump vanillapdf native dependency to 2.3.0

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -77,7 +77,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="vanillapdf" Version="2.3.0-rc.3" />
+    <PackageReference Include="vanillapdf" Version="2.3.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Moves the native `vanillapdf` dependency off the pre-release and onto the stable **2.3.0** package.

This is the last blocker for cutting the stable `vanillapdf.net` 2.3.0 release: `VersionPrefix` is already `2.3.0`, and packing a stable version against a pre-release dependency trips NU5104.

### Change

- `src/vanillapdf.net/vanillapdf.net.csproj`: `vanillapdf` `2.3.0-rc.3` → `2.3.0`

### Impact

The native `v2.3.0` tag is **identical** to `v2.3.0-rc.3` (`compare` reports `identical`, 0 commits ahead), so this carries no code, behaviour, or ABI change and requires no new bindings.

### Verification

- `dotnet restore` resolves `vanillapdf/2.3.0` in `project.assets.json`
- Builds clean, 0 warnings (warnings are errors on net8.0+)
- Full suite: **260 passed, 0 failed** against 2.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)