### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/src/vanillapdf.net/vanillapdf.net.csproj
+++ b/src/vanillapdf.net/vanillapdf.net.csproj
@@ -20,7 +20,7 @@
          pre-release (a stable package must not depend on a pre-release). This has
          no effect on normal build output (the DLL is still produced). -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <Title>vanillapdf.net</Title>
     <Authors>Vanilla.PDF Labs s.r.o.</Authors>
     <PackageProjectUrl>https://vanillapdf.com/</PackageProjectUrl>


### PR DESCRIPTION
Opens the 2.4.0 development line on `main` by moving `<VersionPrefix>` from
`2.3.0` to `2.4.0`.

The `vanillapdf` native dependency intentionally stays at `2.3.0`; it will be
bumped separately once a matching engine release exists.

Note that `VersionPrefix` stays numeric-only — the release pipeline compares the
tag's base version against it and appends any pre-release label via
`--version-suffix` at pack time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)