### PR TITLE
Expose the native Object_Hash API on PdfObject

### DIFF
--- a/src/vanillapdf.net.nunit/PdfSyntax/PdfObjectTest.cs
+++ b/src/vanillapdf.net.nunit/PdfSyntax/PdfObjectTest.cs
@@ -1,0 +1,43 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using vanillapdf.net.PdfSyntax;
+
+namespace vanillapdf.net.nunit.PdfSyntax
+{
+    [TestFixture]
+    public class PdfObjectTest
+    {
+        [Test]
+        public void Hash_SameContent_IsEqual()
+        {
+            using var first = PdfIntegerObject.Create();
+            using var second = PdfIntegerObject.Create();
+
+            first.IntegerValue = 42;
+            second.IntegerValue = 42;
+
+            ClassicAssert.AreEqual(first.Hash, second.Hash);
+        }
+
+        [Test]
+        public void Hash_DifferentContent_Differs()
+        {
+            using var first = PdfIntegerObject.Create();
+            using var second = PdfIntegerObject.Create();
+
+            first.IntegerValue = 42;
+            second.IntegerValue = 43;
+
+            ClassicAssert.AreNotEqual(first.Hash, second.Hash);
+        }
+
+        [Test]
+        public void Hash_RepeatedCalls_AreStable()
+        {
+            using var integerObject = PdfIntegerObject.Create();
+            integerObject.IntegerValue = 42;
+
+            ClassicAssert.AreEqual(integerObject.Hash, integerObject.Hash);
+        }
+    }
+}

--- a/src/vanillapdf.net/Interop/NativeMethods.Syntax.DllImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Syntax.DllImport.cs
@@ -143,6 +143,9 @@ namespace vanillapdf.net.Interop
         [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
         public static extern UInt32 Object_GetAttributeList(PdfObjectSafeHandle handle, out PdfObjectAttributeListSafeHandle data);
 
+        [DllImport(LibraryName, CallingConvention = LibraryCallingConvention)]
+        public static extern UInt32 Object_Hash(PdfObjectSafeHandle handle, out UIntPtr data);
+
         #endregion
 
         #region ArrayObject

--- a/src/vanillapdf.net/Interop/NativeMethods.Syntax.LibraryImport.cs
+++ b/src/vanillapdf.net/Interop/NativeMethods.Syntax.LibraryImport.cs
@@ -119,6 +119,9 @@ namespace vanillapdf.net.Interop
         [LibraryImport(LibraryName)]
         public static partial UInt32 Object_GetAttributeList(PdfObjectSafeHandle handle, out PdfObjectAttributeListSafeHandle data);
 
+        [LibraryImport(LibraryName)]
+        public static partial UInt32 Object_Hash(PdfObjectSafeHandle handle, out UIntPtr data);
+
         #endregion
 
         #region ArrayObject

--- a/src/vanillapdf.net/PdfSyntax/PdfNameObject.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfNameObject.cs
@@ -29,7 +29,7 @@ namespace vanillapdf.net.PdfSyntax
         /// <summary>
         /// Hash value calculated from the name string.
         /// </summary>
-        public UInt64 Hash
+        public override UInt64 Hash
         {
             get { return GetHash(); }
         }

--- a/src/vanillapdf.net/PdfSyntax/PdfObject.cs
+++ b/src/vanillapdf.net/PdfSyntax/PdfObject.cs
@@ -23,6 +23,14 @@ namespace vanillapdf.net.PdfSyntax
         public Int64 Offset => GetOffset();
 
         /// <summary>
+        /// Hash value computed from the content of the object.
+        /// </summary>
+        public virtual UInt64 Hash
+        {
+            get { return GetHash(); }
+        }
+
+        /// <summary>
         /// Get derived type of current object
         /// </summary>
         /// <returns>Type of derived object on success, throws exception on failure</returns>
@@ -52,6 +60,16 @@ namespace vanillapdf.net.PdfSyntax
             }
 
             return data;
+        }
+
+        private UInt64 GetHash()
+        {
+            UInt32 result = NativeMethods.Object_Hash(ObjectHandle, out var data);
+            if (result != PdfReturnValues.ERROR_SUCCESS) {
+                throw PdfErrors.GetLastErrorException();
+            }
+
+            return data.ToUInt64();
         }
 
         private PdfBuffer ToStringInternal()


### PR DESCRIPTION
`Object_Hash` was the one entry point in `c_object.h` with no managed binding —
only its type-specific cousins `NameObject_Hash` and `Buffer_Hash` were exposed.

## Changes

- Bind `Object_Hash` on both interop surfaces (`DllImport` for netstandard2.0,
  `LibraryImport` for net8.0+).
- Expose it as a `virtual UInt64 PdfObject.Hash` property, so every syntax object
  (dictionaries, arrays, streams, integers, …) has a content-based hash.
- `PdfNameObject.Hash` becomes an `override`; it still calls the dedicated
  `NameObject_Hash` entry point.

## Why `GetHashCode`/`Equals` are untouched

The native library has no `Object_Equals` — not in 2.3.0, and not in the current
nightly headers either. Equality would therefore have to be synthesized
managed-side: from the hash (turning collisions into equality) or from `ToPdf()`
byte comparison (two native calls plus two buffer allocations per comparison,
and only consistent with `Object_Hash` if the engine hashes the serialized
form). Value equality on the base class would also propagate to dictionaries,
streams and indirect references, where callers usually mean identity — a
visited-set used for cycle detection while walking the object graph would treat
two structurally identical but distinct objects as already seen.

So the hash is exposed explicitly and equality semantics are unchanged: two
dictionaries with the same entries hash identically but still compare unequal,
which is legal (unequal values may collide). `Equals` and `GetHashCode` should
be added as a pair once native exposes the full equality set.

## Tests

New `PdfSyntax/PdfObjectTest.cs`: same content hashes equal, different content
hashes differ, repeated calls are stable. Full suite passes (263 tests, net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)